### PR TITLE
fix(ci): stop the Pyodide wheel from leaking into the PyPI upload

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: success()
         with:
-          name: wheels-pyodide
+          name: pyodide-wheel
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheels-pyodide
+          name: pyodide-wheel
           path: pyodide-dist
 
       - name: Upload Pyodide wheel as release asset
@@ -119,3 +119,5 @@ jobs:
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
## Summary
- The `Publish to PyPI` workflow run on 2026-07-25 ([run 30178223886](https://github.com/jhavl/spatialgeometry/actions/runs/30178223886)) failed partway through, leaving **1.2.0 as a partial release on PyPI** — missing the cp312-win_amd64 wheel, all four cp313 wheels, and the sdist.
- Root cause: `upload_pypi` downloads artifacts with `pattern: wheels-*`, which also matches the Pyodide job's `wheels-pyodide` artifact. PyPI rejects the `pyodide_*` platform tag with a 400, and twine aborts on the first failure — so everything alphabetically after the pyodide wheel never got uploaded.
- Fix: rename the Pyodide artifact to `pyodide-wheel` so it no longer matches the glob (it's still attached to the GitHub Release separately, as originally intended), and add `skip-existing: true` to the PyPI publish step so re-running the workflow can safely backfill the missing 1.2.0 files without erroring on the ones that already uploaded.

## Test plan
- [ ] Merge and re-run `Publish to PyPI` via `workflow_dispatch` on `main`
- [ ] Confirm `upload_pypi` completes without hitting the pyodide wheel
- [ ] Confirm PyPI now lists cp312-win_amd64, all cp313 wheels, and the sdist for 1.2.0
- [ ] Confirm the Pyodide wasm32 wheel still attaches correctly to a GitHub Release (only fires on `release: created`, not `workflow_dispatch`)