### PR TITLE
ci: make GitHub Release publish the only way to release

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,5 +1,13 @@
 # Build wheels for all platforms and publish to PyPI.
-# Triggered on GitHub release creation or manually via workflow_dispatch.
+#
+# To ship a release: bump the version in pyproject.toml, merge that to
+# main, then on GitHub go to Releases -> "Draft a new release", pick a
+# tag matching the new version, and click "Publish release". That single
+# click is the only trigger for this workflow -- it builds every wheel
+# (including Pyodide/wasm32), uploads everything to PyPI, and attaches
+# the Pyodide wheel to the release as a downloadable asset. There is no
+# separate manual/workflow_dispatch path, so there's only one way to
+# publish and it always does the full job.
 #
 # Uses OIDC trusted publishing -- no stored PyPI token required.
 
@@ -7,8 +15,7 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [created]
-  workflow_dispatch:
+    types: [published]
 
 jobs:
   build_wheels:
@@ -84,7 +91,7 @@ jobs:
   upload_pyodide_asset:
     name: Attach Pyodide wheel to GitHub release
     needs: build_pyodide
-    if: github.event_name == 'release' && needs.build_pyodide.result == 'success'
+    if: needs.build_pyodide.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Follow-up to #9. That PR fixed the Pyodide-wheel-leaking-into-PyPI bug, but the workflow still had two different triggers (`release: created` and `workflow_dispatch`) that behaved differently: dispatching manually skipped the job that attaches the Pyodide wheel to the release, which is exactly what happened on the 2026-07-25 release attempt.
- This collapses publishing to a single, unambiguous action: creating and publishing a GitHub Release. There's no more manual-trigger path that silently does less than the real one.
- Also switched `created` -> `published` -- `created` also fires when a release draft is merely saved, not just when it's actually published, which isn't the event you want kicking off a PyPI upload.
- Added a plain-language comment at the top of the workflow describing the one-step release process: bump the version, merge, then "Draft a new release" -> pick the tag -> "Publish release". That single click now always does the full job (all wheels, PyPI, and the Pyodide release asset).

## Test plan
- [ ] Merge, then bump the version and publish a real GitHub Release
- [ ] Confirm all wheels + sdist land on PyPI for the new version
- [ ] Confirm the Pyodide wasm32 wheel is attached to the GitHub Release as an asset
- [ ] Confirm `workflow_dispatch` no longer appears as a trigger option for this workflow