### PR TITLE
fix(docs): install the collision extra for the docs build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install docs dependencies
         run: |
-          pip install .[docs]
+          pip install .[docs,collision]
           pip install sympy
           sudo apt-get install -y graphviz
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ required there.
 > version range Coal needs), so the `collision` extra skips it there and
 > collision checking is unavailable via `pip` on Windows. Everything else
 > in the package works normally.
+>
+> Workaround: conda-forge publishes `coal-python` built for `win-64`
+> against its own assimp, sidestepping the missing wheel entirely:
+>
+> ```shell
+> conda install -c conda-forge coal-python
+> pip install spatialgeometry trimesh
+> ```
 
 ### conda / conda-forge
 


### PR DESCRIPTION
## Summary
- `docs/source/intro.rst` uses `sphinx-autorun` (`.. runblock:: pycon`) to actually run a `closest_point()`/`iscollided()` example and embed its real output in the page — but the docs-build CI job only ran `pip install .[docs]`, which doesn't include `coal`. The example failed with `ModuleNotFoundError: No module named 'coal'`, and that traceback got baked straight into the rendered docs page.
- `sphinx-autorun` doesn't fail the Sphinx build when the code it executes raises — it just captures whatever came out (including a traceback) as page content — so CI reported green the whole time. Verified locally: with `coal` installed, the same block produces the expected `d=1.0` / point / `False` output.
- Fix: install the `collision` extra alongside `docs` for the docs-build job.
- Also documented the conda-forge `coal-python` workaround for Windows in the README, since `pip install spatialgeometry[collision]` skips coal there (no Windows wheel for one of its own dependencies).

## Test plan
- [ ] Docs-build CI job passes and the "Measure the distance" section renders real output, not a traceback
- [ ] Spot check the built docs page for `Traceback` anywhere else on the page