### PR TITLE
feat: add Path shape -- a polyline through a sequence of waypoints

### DIFF
--- a/src/spatialgeometry/__init__.py
+++ b/src/spatialgeometry/__init__.py
@@ -4,6 +4,7 @@ from spatialgeometry.geom import (
     Shape,
     Axes,
     Arrow,
+    Path,
     CollisionShape,
     Mesh,
     Cylinder,
@@ -27,6 +28,7 @@ __all__ = [
     "Sphere",
     "Axes",
     "Arrow",
+    "Path",
     "SceneNode",
     "SceneGroup",
 ]

--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -487,3 +487,90 @@ class Arrow(Shape):
         shape["head_length"] = self.head_length
         shape["head_radius"] = self.head_radius
         return shape
+
+
+class Path(Shape):
+    """A polyline through a sequence of waypoints -- straight segments
+    joining consecutive points, not a smoothed curve -- for drawing
+    paths and trajectories in the scene.
+
+    :param points: waypoints defining the polyline
+    :type points: ArrayLike
+    :param radius: tube radius; if 0, rendered as a line instead of a
+        tube -- see linewidth. radius and linewidth are mutually
+        exclusive: radius > 0 always takes precedence, and linewidth is
+        ignored in that case (a real tube mesh has no notion of a pixel
+        width).
+    :param linewidth: Width of the line in pixels. Only used when
+        radius == 0.
+
+    :param pose: Local reference frame of the shape
+    :type pose: SE3
+    """
+
+    def __init__(
+        self,
+        points: ArrayLike,
+        radius: float = 0.0,
+        linewidth: float = 1.0,
+        **kwargs,
+    ):
+        super(Path, self).__init__(stype="path", **kwargs)
+        self.points = points
+        self.radius = radius
+        self.linewidth = linewidth
+
+    @property
+    def points(self) -> np.ndarray:
+        """
+        :rtype: ndarray(3,n)
+        """
+        return self._points
+
+    @points.setter
+    @update
+    def points(self, value):
+        value = np.array(value, dtype=float)
+        if value.ndim != 2 or value.shape[0] != 3:
+            raise ValueError(
+                f"points must be a 3xN array of waypoints, got shape {value.shape}"
+            )
+        if value.shape[1] < 2:
+            raise ValueError("points must contain at least 2 waypoints")
+        self._points = value
+
+    @property
+    def radius(self):
+        return self._radius
+
+    @radius.setter
+    @update
+    def radius(self, value):
+        self._radius = float(value)
+
+    @property
+    def linewidth(self):
+        return self._linewidth
+
+    @linewidth.setter
+    @update
+    def linewidth(self, value):
+        self._linewidth = float(value)
+
+    def to_dict(self):
+        """
+        to_dict() returns the shapes information in dictionary form
+
+        :returns: All information about the shape
+        :rtype: dict
+        """
+
+        shape = super().to_dict()
+        # Wire format is a flat list of [x, y, z] waypoints (N x 3) -- the
+        # natural shape for the JS side to consume directly (one
+        # THREE.Vector3 per point) -- even though points is stored/accepted
+        # here as 3xN, matching this ecosystem's own point-set convention.
+        shape["points"] = self.points.T.tolist()
+        shape["radius"] = self.radius
+        shape["linewidth"] = self.linewidth
+        return shape

--- a/src/spatialgeometry/geom/__init__.py
+++ b/src/spatialgeometry/geom/__init__.py
@@ -1,6 +1,6 @@
 from spatialgeometry.geom.SceneNode import SceneNode
 from spatialgeometry.geom.SceneGroup import SceneGroup
-from spatialgeometry.geom.Shape import Shape, Axes, Arrow
+from spatialgeometry.geom.Shape import Shape, Axes, Arrow, Path
 from spatialgeometry.geom.CollisionShape import (
     CollisionShape,
     Mesh,
@@ -21,6 +21,7 @@ __all__ = [
     "Sphere",
     "Axes",
     "Arrow",
+    "Path",
     "SceneNode",
     "SceneGroup",
 ]

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -281,6 +281,49 @@ class TestShape(unittest.TestCase):
         self.assertEqual(d["radius"], 0.1)
         self.assertEqual(d["linewidth"], 5.0)
 
+    def test_Path_defaults(self):
+        # points is accepted/stored as 3xN (this ecosystem's own point-set
+        # convention), but the wire format transposes to a flat N x 3 list
+        # of [x, y, z] waypoints -- the natural shape for the JS side to
+        # build one THREE.Vector3 per point.
+        points = np.array([[0.0, 1.0, 2.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        s0 = gm.Path(points)
+
+        ans = {
+            "stype": "path",
+            "t": [0.0, 0.0, 0.0],
+            "q": [0.0, 0.0, 0.0, 1],
+            "v": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "color": 5000268,
+            "opacity": 1.0,
+            "points": [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+            "radius": 0.0,
+            "linewidth": 1.0,
+        }
+
+        self.assertEqual(s0.to_dict(), ans)
+
+    def test_Path_radius_and_linewidth_are_independent_params(self):
+        points = np.array([[0.0, 1.0], [0.0, 0.0], [0.0, 0.0]])
+        s0 = gm.Path(points, radius=0.05, linewidth=3.0)
+
+        d = s0.to_dict()
+        self.assertEqual(d["radius"], 0.05)
+        self.assertEqual(d["linewidth"], 3.0)
+
+    def test_Path_rejects_wrong_shape(self):
+        with self.assertRaises(ValueError):
+            gm.Path(np.zeros((2, 3)))  # not 3xN
+
+    def test_Path_rejects_too_few_points(self):
+        with self.assertRaises(ValueError):
+            gm.Path(np.zeros((3, 1)))  # a single point isn't a polyline
+
+    def test_Path_accepts_plain_list_input(self):
+        # points is documented as ArrayLike, not just ndarray.
+        s0 = gm.Path([[0, 1], [0, 0], [0, 0]])
+        self.assertEqual(s0.to_dict()["points"], [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+
 
 if __name__ == "__main__":  # pragma nocover
     unittest.main()


### PR DESCRIPTION
## Summary

Companion PR to a swift-side rendering PR (to follow) -- together these
address jhavl/swift#51 ("Drawing lines/trajectories in Swift").

## Changes

- `Path(points, radius=0.0, linewidth=1.0, **kwargs)` -- `points` is a
  3xN array of waypoints (this ecosystem's own point-set convention),
  stored/validated as such. Wire format transposes to a flat Nx3 list
  of `[x, y, z]` waypoints -- the natural shape for the JS side to
  consume directly (one `THREE.Vector3` per point).
- `radius`/`linewidth` mirror `Arrow`'s already-established mutual
  exclusivity: `radius > 0` renders as a real tube, `radius == 0`
  (default) renders as a line honoring `linewidth`.
- Deliberately a plain `Shape`, not `CollisionShape` -- Coal has no
  native "tube along a polyline" primitive, and `CollisionShape` here
  only supports one `coal.CollisionObject` per shape, so a collidable
  tube would need real framework changes (multi-geometry support) or a
  generated BVH mesh. Out of scope here -- this PR only covers the
  originally-scoped visual primitive ("points, line width, color").

## Test plan

- [x] `pytest tests/` -- 99 passed.