### PR TITLE
fix: Shape.color setter left an all-integer input as int64

### DIFF
--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -252,7 +252,16 @@ class Shape(SceneNode):
         elif value is None:
             value = default_color
         else:
-            value = array(value)
+            # dtype=float forced explicitly -- an all-integer input (e.g.
+            # the very natural color=[1, 0, 0, 1] for opaque red) would
+            # otherwise stay int64 whenever nothing needs 0-255
+            # normalisation below, and self.color[3] (opacity) being a
+            # numpy.int64 rather than a float breaks real (non-mocked)
+            # json.dumps() sends in SwiftRoute.py -- TypeError: Object of
+            # type int64 is not JSON serializable. Never caught by the
+            # existing protocol tests since they're FakeBrowser-mocked and
+            # never actually round-trip through json.dumps().
+            value = array(value, dtype=float)
 
             if any(value > 1.0):
                 value = value / 255.0

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -49,6 +49,23 @@ class TestShape(unittest.TestCase):
         self.assertAlmostEqual(shape.color[2], 250 / 255)
         self.assertEqual(shape.color[3], 100 / 255)
 
+    def test_color_setter_all_integer_input_stays_json_serializable(self):
+        # Regression test: color=[1, 0, 0, 1] (a natural way to write
+        # "opaque red") used to leave self._color as numpy int64 -- nothing
+        # here needs 0-255 normalisation (all values <= 1), so the only
+        # thing that made 3-length int input safe by accident was
+        # concatenate()'s promotion when appending the alpha default; a
+        # fully-specified 4-length int color skipped that entirely.
+        # self.color[3] (opacity) being int64 broke real (non-mocked)
+        # json.dumps() sends in SwiftRoute.py, uncaught by any existing
+        # test since they're all FakeBrowser-mocked.
+        import json
+
+        shape = gm.Cuboid([1, 1, 1], color=[1, 0, 0, 1])
+
+        self.assertIsInstance(shape.color[3], float)
+        json.dumps(shape.to_dict())  # must not raise TypeError
+
     def test_to_dict(self):
         s1 = gm.Cylinder(1, 1)
 


### PR DESCRIPTION
## Summary

`color=[1, 0, 0, 1]` -- a very natural way to write "opaque red" --
left `self._color` (and so `self.color[3]`, opacity) as `numpy.int64`
rather than a plain float. Nothing needs 0-255 normalisation when every
value is <= 1, so the only thing that made a *3-length* int color safe
was `concatenate()`'s dtype promotion when appending the alpha default
-- a fully-specified *4-length* int color skipped that entirely.

`opacity` being `numpy.int64` breaks real (non-mocked) `json.dumps()`
sends in swift's `SwiftRoute.py`: `TypeError: Object of type int64 is
not JSON serializable`.

Found live-testing `spatialgeometry.Path` in swift -- unrelated to
`Path` itself, own branch per usual practice. Never caught by the
existing test suite because swift's own protocol tests are entirely
`FakeBrowser`-mocked -- no real `json.dumps()` ever runs in that path.

## Fix

Force `dtype=float` where the color array is built, so this can't
depend on which branch happens to trigger a promotion.

## Test plan

- [x] `pytest tests/` -- 95 passed, including a new
      `test_color_setter_all_integer_input_stays_json_serializable`
      that asserts `json.dumps(shape.to_dict())` doesn't raise.
- [x] Verified fixed end-to-end with a real swift browser round-trip
      (not just the unit test) -- `env.add(sg.Cuboid(..., color=[1, 0,
      0, 1]))` no longer crashes the websocket send.