### PR TITLE
Code review fixes: abstract base classes, type hints, repr/str, __version__

### DIFF
--- a/src/spatialgeometry/__init__.py
+++ b/src/spatialgeometry/__init__.py
@@ -30,3 +30,10 @@ __all__ = [
     "SceneNode",
     "SceneGroup",
 ]
+
+try:
+    import importlib.metadata
+
+    __version__ = importlib.metadata.version("spatialgeometry")
+except importlib.metadata.PackageNotFoundError:
+    pass

--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -3,22 +3,23 @@
 @author: Jesse Haviland
 """
 
+from __future__ import annotations
+
 import sys
-import os
 from abc import abstractmethod
+from typing import Any
+
 import numpy as np
 from spatialmath.base.argcheck import getvector
 from spatialgeometry.geom import Shape
-from spatialgeometry.geom.Shape import update
+from spatialgeometry.geom.Shape import ArrayLike, update
 from warnings import warn
-
-from typing import Tuple, Union
 
 # Module-level coal reference — populated on first use, never in Pyodide.
 _coal = None
 
 
-def _require_coal():
+def _require_coal() -> None:
     """Import coal on first use; raise clearly if unavailable."""
     global _coal
     if _coal is not None:
@@ -39,23 +40,23 @@ def _require_coal():
 
 
 class CollisionShape(Shape):
-    def __init__(self, collision=True, **kwargs):
+    def __init__(self, collision: bool = True, **kwargs) -> None:
         self.co = None      # coal.CollisionObject, created on first use
         self._cinit = False
         super().__init__(**kwargs)
         self._collision = collision
 
-    def _update_coal(self):
+    def _update_coal(self) -> None:
         """Push the current world transform into the Coal collision object."""
         if self.co is not None:
             self.co.setTranslation(self._wT[:3, 3])
             self.co.setRotation(self._wT[:3, :3])
 
     @abstractmethod
-    def _init_coal(self):  # overridden by each subclass
-        pass
+    def _init_coal(self) -> None:
+        """Build this shape's Coal collision geometry. Implemented by each concrete subclass."""
 
-    def _ensure_coal(self):
+    def _ensure_coal(self) -> None:
         """Guarantee Coal is loaded and this object's Coal twin is current."""
         _require_coal()
         if not self._cinit:
@@ -63,8 +64,8 @@ class CollisionShape(Shape):
         self._update_coal()
 
     def closest_point(
-        self, shape: "CollisionShape", inf_dist: float = 1.0
-    ) -> Tuple[Union[float, None], Union[np.ndarray, None], Union[np.ndarray, None]]:
+        self, shape: CollisionShape, inf_dist: float = 1.0
+    ) -> tuple[float | None, np.ndarray | None, np.ndarray | None]:
         """
         Return the minimum euclidean distance between self and shape.
 
@@ -87,7 +88,7 @@ class CollisionShape(Shape):
             return None, None, None
         return d, np.array(res.getNearestPoint1()), np.array(res.getNearestPoint2())
 
-    def iscollided(self, shape: "CollisionShape") -> bool:
+    def iscollided(self, shape: CollisionShape) -> bool:
         """
         Return True if self and shape have collided (distance ≤ 0).
 
@@ -96,7 +97,7 @@ class CollisionShape(Shape):
         d, _, _ = self.closest_point(shape)
         return d is not None and d <= 0
 
-    def collided(self, shape: "CollisionShape") -> bool:
+    def collided(self, shape: CollisionShape) -> bool:
         """Deprecated — use iscollided instead."""
         warn("collided is deprecated, use iscollided instead", FutureWarning)
         return self.iscollided(shape)
@@ -111,12 +112,14 @@ class Mesh(CollisionShape):
     :param collision: Whether this shape participates in collision checking.
     """
 
-    def __init__(self, filename=None, scale=[1, 1, 1], **kwargs):
+    def __init__(
+        self, filename: str | None = None, scale: ArrayLike = [1, 1, 1], **kwargs
+    ) -> None:
         super().__init__(stype="mesh", **kwargs)
         self.filename = filename
         self.scale = scale
 
-    def _init_coal(self):
+    def _init_coal(self) -> None:
         if not self.collision:
             raise ValueError(
                 "This shape has collision=False and cannot be used as a collision object"
@@ -148,20 +151,20 @@ class Mesh(CollisionShape):
 
     @scale.setter
     @update
-    def scale(self, value):
+    def scale(self, value: ArrayLike) -> None:
         value = getvector(value if value is not None else [1, 1, 1], 3)
         self._scale = np.array(value)
 
     @property
-    def filename(self):
+    def filename(self) -> str | None:
         return self._filename
 
     @filename.setter
     @update
-    def filename(self, value):
+    def filename(self, value: str | None) -> None:
         self._filename = value
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         shape = super().to_dict()
         shape["filename"] = self.filename
         shape["scale"] = self.scale.tolist()
@@ -177,12 +180,12 @@ class Cylinder(CollisionShape):
     :param collision: Whether this shape participates in collision checking.
     """
 
-    def __init__(self, radius, length, **kwargs):
+    def __init__(self, radius: float, length: float, **kwargs) -> None:
         super().__init__(stype="cylinder", **kwargs)
         self.radius = radius
         self.length = length
 
-    def _init_coal(self):
+    def _init_coal(self) -> None:
         if not self.collision:
             raise ValueError(
                 "This shape has collision=False and cannot be used as a collision object"
@@ -193,24 +196,24 @@ class Cylinder(CollisionShape):
         self._cinit = True
 
     @property
-    def radius(self):
+    def radius(self) -> float:
         return self._radius
 
     @radius.setter
     @update
-    def radius(self, value):
+    def radius(self, value: float) -> None:
         self._radius = float(value)
 
     @property
-    def length(self):
+    def length(self) -> float:
         return self._length
 
     @length.setter
     @update
-    def length(self, value):
+    def length(self, value: float) -> None:
         self._length = float(value)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         shape = super().to_dict()
         shape["radius"] = self.radius
         shape["length"] = self.length
@@ -225,11 +228,11 @@ class Sphere(CollisionShape):
     :param collision: Whether this shape participates in collision checking.
     """
 
-    def __init__(self, radius, **kwargs):
+    def __init__(self, radius: float, **kwargs) -> None:
         super().__init__(stype="sphere", **kwargs)
         self.radius = radius
 
-    def _init_coal(self):
+    def _init_coal(self) -> None:
         if not self.collision:
             raise ValueError(
                 "This shape has collision=False and cannot be used as a collision object"
@@ -238,15 +241,15 @@ class Sphere(CollisionShape):
         self._cinit = True
 
     @property
-    def radius(self):
+    def radius(self) -> float:
         return self._radius
 
     @radius.setter
     @update
-    def radius(self, value):
+    def radius(self, value: float) -> None:
         self._radius = float(value)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         shape = super().to_dict()
         shape["radius"] = self.radius
         return shape
@@ -260,11 +263,11 @@ class Cuboid(CollisionShape):
     :param collision: Whether this shape participates in collision checking.
     """
 
-    def __init__(self, scale, **kwargs):
+    def __init__(self, scale: ArrayLike, **kwargs) -> None:
         super().__init__(stype="cuboid", **kwargs)
         self.scale = scale
 
-    def _init_coal(self):
+    def _init_coal(self) -> None:
         if not self.collision:
             raise ValueError(
                 "This shape has collision=False and cannot be used as a collision object"
@@ -280,17 +283,17 @@ class Cuboid(CollisionShape):
 
     @scale.setter
     @update
-    def scale(self, value):
+    def scale(self, value: ArrayLike) -> None:
         value = getvector(value if value is not None else [1, 1, 1], 3)
         self._scale = np.array(value)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         shape = super().to_dict()
         shape["scale"] = self.scale.tolist()
         return shape
 
 
 class Box(Cuboid):
-    def __init__(self, scale, **kwargs):
+    def __init__(self, scale: ArrayLike, **kwargs) -> None:
         warn("Box is deprecated, use Cuboid instead", FutureWarning)
         super().__init__(scale, **kwargs)

--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -5,6 +5,7 @@
 
 import sys
 import os
+from abc import abstractmethod
 import numpy as np
 from spatialmath.base.argcheck import getvector
 from spatialgeometry.geom import Shape
@@ -50,6 +51,7 @@ class CollisionShape(Shape):
             self.co.setTranslation(self._wT[:3, 3])
             self.co.setRotation(self._wT[:3, :3])
 
+    @abstractmethod
     def _init_coal(self):  # overridden by each subclass
         pass
 

--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -112,6 +112,8 @@ class Mesh(CollisionShape):
     :param collision: Whether this shape participates in collision checking.
     """
 
+    _repr_params = ("filename", "scale")
+
     def __init__(
         self, filename: str | None = None, scale: ArrayLike = [1, 1, 1], **kwargs
     ) -> None:
@@ -180,6 +182,8 @@ class Cylinder(CollisionShape):
     :param collision: Whether this shape participates in collision checking.
     """
 
+    _repr_params = ("radius", "length")
+
     def __init__(self, radius: float, length: float, **kwargs) -> None:
         super().__init__(stype="cylinder", **kwargs)
         self.radius = radius
@@ -228,6 +232,8 @@ class Sphere(CollisionShape):
     :param collision: Whether this shape participates in collision checking.
     """
 
+    _repr_params = ("radius",)
+
     def __init__(self, radius: float, **kwargs) -> None:
         super().__init__(stype="sphere", **kwargs)
         self.radius = radius
@@ -262,6 +268,8 @@ class Cuboid(CollisionShape):
     :param scale: [length, width, height] in metres.
     :param collision: Whether this shape participates in collision checking.
     """
+
+    _repr_params = ("scale",)
 
     def __init__(self, scale: ArrayLike, **kwargs) -> None:
         super().__init__(stype="cuboid", **kwargs)

--- a/src/spatialgeometry/geom/SceneGroup.py
+++ b/src/spatialgeometry/geom/SceneGroup.py
@@ -3,24 +3,20 @@
 @author: Jesse Haviland
 """
 
-from numpy import ndarray, eye, zeros, copy as npcopy
-from spatialmath.base import r2q
-from abc import ABC
-from collections import UserList
+from __future__ import annotations
 
-# from roboticstoolbox.robot.ETS import ETS
-from typing import Type
+from collections import UserList
 
 from spatialgeometry.geom.SceneNode import SceneNode
 
 
 class SceneGroup(SceneNode, UserList):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
     def __getitem__(self, i: int) -> SceneNode:
         return self._scene_children[i]
 
     @property
-    def data(self):
+    def data(self) -> list[SceneNode]:
         return self._scene_children

--- a/src/spatialgeometry/geom/SceneGroup.py
+++ b/src/spatialgeometry/geom/SceneGroup.py
@@ -20,3 +20,6 @@ class SceneGroup(SceneNode, UserList):
     @property
     def data(self) -> list[SceneNode]:
         return self._scene_children
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.data!r})"

--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -280,6 +280,16 @@ class SceneNode:
 
         self.__wq[:] = r2q(self.__wT[:3, :3], order="xyzs")
 
+    @property
+    def T(self) -> ndarray:
+        return self._T
+
+    @T.setter
+    def T(self, T_new: ndarray | SE3) -> None:
+        if isinstance(T_new, SE3):
+            T_new = T_new.A
+        self._T = T_new
+
     # --------------------------------------------------------------------- #
     # Scene transform propogation methods
     #

--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -146,15 +146,7 @@ class SceneNode:
         return result
 
     def __str__(self) -> str:
-        if self._scene_parent is not None:
-            parent = f"{SE3(self._scene_parent._T, check=False).t}"
-        else:
-            parent = "None"
-
-        return f"parent: {parent} \n self: {SE3(self._T).t} \n children: {[SE3(child._T).t for child in self._scene_children]}"
-
-        # parent = self.scene_parent
-        # return f"parent: {hex(id(parent)) if parent is not None else None} \n self: {hex(id(self))} \n children: {[hex(id(child)) for child in self.scene_children]}"
+        return f"{type(self).__name__} at {SE3(self._T, check=False).strline()}"
 
     # --------------------------------------------------------------------- #
 

--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -274,7 +274,7 @@ class SceneNode:
         self.__T[:] = T.copy(order="F")
 
         if self._scene_parent is not None:
-            self.__wT[:] = self.parent.wT @ self._T
+            self.__wT[:] = self._scene_parent._wT @ self._T
         else:
             self.__wT[:] = self._T
 

--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -3,24 +3,22 @@
 @author: Jesse Haviland
 """
 
+from __future__ import annotations
+
 from numpy import ndarray, eye, copy as npcopy, array
 from spatialmath.base import r2q
-from abc import ABC
 from spatialgeometry.scene import node_init, node_update, scene_graph_children, scene_graph_tree
 from spatialmath import SE3
 from copy import deepcopy
-
-# from roboticstoolbox.robot.ETS import ETS
-from typing import Type, Union, List
 
 
 class SceneNode:
     def __init__(
         self,
         T: ndarray = eye(4),
-        scene_parent: Union["SceneNode", None] = None,
-        scene_children: Union[List["SceneNode"], None] = None,
-    ):
+        scene_parent: SceneNode | None = None,
+        scene_children: list[SceneNode] | None = None,
+    ) -> None:
         # These three are static attributes which can never be changed
         # If these are directly accessed and re-written, segmentation faults
         # will follow very soon after
@@ -63,9 +61,9 @@ class SceneNode:
     def _custom_scene_node_init(
         self,
         T: ndarray = eye(4),
-        scene_parent: Union["SceneNode", None] = None,
-        scene_children: Union[List["SceneNode"], None] = None,
-    ):
+        scene_parent: SceneNode | None = None,
+        scene_children: list[SceneNode] | None = None,
+    ) -> None:
         # The world transform
         self.__wT = eye(4).copy(order="F")
 
@@ -161,7 +159,7 @@ class SceneNode:
     # --------------------------------------------------------------------- #
 
     @property
-    def scene_parent(self) -> Type["SceneNode"]:
+    def scene_parent(self) -> SceneNode | None:
         """
         Returns the parent node of this object
 
@@ -169,7 +167,7 @@ class SceneNode:
         return self._scene_parent
 
     @scene_parent.setter
-    def scene_parent(self, parent: "SceneNode"):
+    def scene_parent(self, parent: SceneNode) -> None:
         """
         Sets a new parent node of this object, will automatically update
         the parents child
@@ -184,7 +182,7 @@ class SceneNode:
         # Update c
         self.__update_c()
 
-    def _update_scene_parent(self, parent: "SceneNode"):
+    def _update_scene_parent(self, parent: SceneNode) -> None:
         """
         Sets a new parent node of this object, does NOT update
         the parents child
@@ -198,7 +196,7 @@ class SceneNode:
     # --------------------------------------------------------------------- #
 
     @property
-    def scene_children(self) -> List["SceneNode"]:
+    def scene_children(self) -> list[SceneNode]:
         """
         Returns the child nodes of this object
 
@@ -206,7 +204,7 @@ class SceneNode:
         return self._scene_children
 
     @scene_children.setter
-    def scene_children(self, children: List["SceneNode"]):
+    def scene_children(self, children: list[SceneNode]) -> None:
         """
         Sets the child nodes of this object, does not update childs
         parent
@@ -222,7 +220,7 @@ class SceneNode:
         # Update c
         self.__update_c()
 
-    def _update_scene_children(self, child: "SceneNode"):
+    def _update_scene_children(self, child: SceneNode) -> None:
         """
         Appends a new child to this object, does NOT update
         the childs parent
@@ -306,10 +304,10 @@ class SceneNode:
 
     # --------------------------------------------------------------------- #
 
-    def attach(self, object: "SceneNode"):
+    def attach(self, object: SceneNode) -> None:
         new_childs = self.scene_children
         new_childs.append(object)
         self.scene_children = new_childs
 
-    def attach_to(self, object: "SceneNode"):
+    def attach_to(self, object: SceneNode) -> None:
         self.scene_parent = object

--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -3,13 +3,13 @@
 @author: Jesse Haviland
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from functools import wraps
-from multiprocessing.sharedctypes import Value
 from spatialgeometry.geom.SceneNode import SceneNode
 from spatialmath import SE3
 from spatialmath.base.argcheck import getvector
-from spatialmath.base import r2q
 from copy import copy as ccopy, deepcopy
 from numpy import (
     ndarray,
@@ -22,13 +22,12 @@ from numpy import (
     eye,
     array_equal,
 )
-from typing import Union, Tuple, Dict, Any
+from typing import Any
 from warnings import warn
 
-import spatialmath.base as smb
 import numpy as np
 
-ArrayLike = Union[list, ndarray, tuple, set]
+ArrayLike = list | ndarray | tuple | set
 _mpl = False
 # _rtb = False
 
@@ -67,12 +66,12 @@ CONST_RX = SE3.Rx(pi / 2).A
 class Shape(SceneNode, ABC):
     def __init__(
         self,
-        pose: Union[ndarray, SE3] = eye(4),
-        color: ArrayLike = None,
-        stype: str = None,
-        base: Union[ndarray, SE3, None] = None,
+        pose: ndarray | SE3 = eye(4),
+        color: ArrayLike | None = None,
+        stype: str | None = None,
+        base: ndarray | SE3 | None = None,
         **kwargs,
-    ):
+    ) -> None:
 
         # Swift related attributes
         self._added_to_swift = False
@@ -114,7 +113,7 @@ class Shape(SceneNode, ABC):
 
     # --------------------------------------------------------------------- #
 
-    def copy(self) -> "Shape":
+    def copy(self) -> Shape:
         """
         Copy of Shape object
 
@@ -152,12 +151,12 @@ class Shape(SceneNode, ABC):
 
     # --------------------------------------------------------------------- #
 
-    def _to_hex(self, rgb) -> int:
+    def _to_hex(self, rgb: ArrayLike) -> int:
         rgb = (array(rgb) * 255).astype(int)
         return int("0x%02x%02x%02x" % (rgb[0], rgb[1], rgb[2]), 16)
 
     @abstractmethod
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         to_dict() returns the shapes information in dictionary form
 
@@ -177,7 +176,7 @@ class Shape(SceneNode, ABC):
 
         return shape
 
-    def fk_dict(self) -> Dict[str, Any]:
+    def fk_dict(self) -> dict[str, Any]:
         """
         fk_dict() outputs shapes pose in dictionary form
 
@@ -206,11 +205,11 @@ class Shape(SceneNode, ABC):
         return self._v
 
     @v.setter
-    def v(self, value: ArrayLike):
+    def v(self, value: ArrayLike) -> None:
         self._v = array(getvector(value, 6))
 
     @property
-    def color(self) -> Tuple[float, float, float, float]:
+    def color(self) -> tuple[float, float, float, float]:
         """
         shape.color returns a four length tuple representing (red, green, blue, alpha)
         where alpha represents transparency. Values returned are in the range [0-1].
@@ -219,7 +218,7 @@ class Shape(SceneNode, ABC):
 
     @color.setter
     @update
-    def color(self, value: ArrayLike):
+    def color(self, value: ArrayLike) -> None:
         """
         shape.color(new_color) sets the color of a shape.
 
@@ -266,7 +265,7 @@ class Shape(SceneNode, ABC):
 
         self._color = value
 
-    def set_alpha(self, alpha: Union[float, int]):
+    def set_alpha(self, alpha: float | int) -> None:
         """
         Convenience method to set the opacity/alpha value of the robots color.
         """
@@ -286,7 +285,7 @@ class Shape(SceneNode, ABC):
         return self._T
 
     @T.setter
-    def T(self, T_new: Union[ndarray, SE3]):
+    def T(self, T_new: ndarray | SE3) -> None:
         if isinstance(T_new, SE3):
             T_new = T_new.A
         self._T = T_new
@@ -319,12 +318,12 @@ class Axes(Shape):
 
     def __init__(
         self,
-        length,
+        length: float,
         arrows: bool = False,
         radius: float = 0.0,
         linewidth: float = 1.0,
         **kwargs,
-    ):
+    ) -> None:
         super(Axes, self).__init__(stype="axes", **kwargs)
         self.length = length
         self.arrows = arrows
@@ -332,42 +331,42 @@ class Axes(Shape):
         self.linewidth = linewidth
 
     @property
-    def length(self):
+    def length(self) -> float:
         return self._length
 
     @length.setter
     @update
-    def length(self, value):
+    def length(self, value: float) -> None:
         self._length = float(value)
 
     @property
-    def arrows(self):
+    def arrows(self) -> bool:
         return self._arrows
 
     @arrows.setter
     @update
-    def arrows(self, value):
+    def arrows(self, value: bool) -> None:
         self._arrows = bool(value)
 
     @property
-    def radius(self):
+    def radius(self) -> float:
         return self._radius
 
     @radius.setter
     @update
-    def radius(self, value):
+    def radius(self, value: float) -> None:
         self._radius = float(value)
 
     @property
-    def linewidth(self):
+    def linewidth(self) -> float:
         return self._linewidth
 
     @linewidth.setter
     @update
-    def linewidth(self, value):
+    def linewidth(self, value: float) -> None:
         self._linewidth = float(value)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         """
         to_dict() returns the shapes information in dictionary form
 
@@ -418,7 +417,7 @@ class Arrow(Shape):
         head_length: float = 0.2,
         head_radius: float = 0.2,
         **kwargs,
-    ):
+    ) -> None:
         if head_length > 1.0 or head_length < 0.0:
             raise ValueError("Head length must be a value between 0 and 1")
 
@@ -430,51 +429,51 @@ class Arrow(Shape):
         self.head_radius = head_radius
 
     @property
-    def length(self):
+    def length(self) -> float:
         return self._length
 
     @length.setter
     @update
-    def length(self, value):
+    def length(self, value: float) -> None:
         self._length = float(value)
 
     @property
-    def radius(self):
+    def radius(self) -> float:
         return self._radius
 
     @radius.setter
     @update
-    def radius(self, value):
+    def radius(self, value: float) -> None:
         self._radius = float(value)
 
     @property
-    def linewidth(self):
+    def linewidth(self) -> float:
         return self._linewidth
 
     @linewidth.setter
     @update
-    def linewidth(self, value):
+    def linewidth(self, value: float) -> None:
         self._linewidth = float(value)
 
     @property
-    def head_length(self):
+    def head_length(self) -> float:
         return self._head_length
 
     @head_length.setter
     @update
-    def head_length(self, value):
+    def head_length(self, value: float) -> None:
         self._head_length = float(value)
 
     @property
-    def head_radius(self):
+    def head_radius(self) -> float:
         return self._head_radius
 
     @head_radius.setter
     @update
-    def head_radius(self, value):
+    def head_radius(self, value: float) -> None:
         self._head_radius = float(value)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         """
         to_dict() returns the shapes information in dictionary form
 

--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -64,6 +64,10 @@ CONST_RX = SE3.Rx(pi / 2).A
 
 
 class Shape(SceneNode, ABC):
+    #: Names of this class's own constructor arguments to include in
+    #: :meth:`__repr__`, in the order they should appear.
+    _repr_params: tuple[str, ...] = ()
+
     def __init__(
         self,
         pose: ndarray | SE3 = eye(4),
@@ -146,9 +150,6 @@ class Shape(SceneNode, ABC):
 
         return result
 
-    def __str__(self) -> str:
-        return f"stype: {self.stype} \n pose: {SE3(self._T).t}"
-
     # --------------------------------------------------------------------- #
 
     def _to_hex(self, rgb: ArrayLike) -> int:
@@ -192,9 +193,15 @@ class Shape(SceneNode, ABC):
 
         return shape
 
-    def __repr__(self) -> str:  # pragma nocover
-        return f"{self.stype},\n{self.T[:3, -1]}"
-        # return f"{hex(id(self.stype))}"
+    def __repr__(self) -> str:
+        args = []
+        for name in self._repr_params:
+            value = getattr(self, name)
+            if isinstance(value, ndarray):
+                value = value.tolist()
+            args.append(f"{name}={value!r}")
+        args.append(f"pose={SE3(self._T, check=False).strline()!r}")
+        return f"{type(self).__name__}({', '.join(args)})"
 
     @property
     def collision(self) -> bool:
@@ -302,6 +309,8 @@ class Axes(Shape):
 
     """
 
+    _repr_params = ("length", "arrows", "radius", "linewidth")
+
     def __init__(
         self,
         length: float,
@@ -394,6 +403,8 @@ class Arrow(Shape):
     :type pose: SE3
 
     """
+
+    _repr_params = ("length", "radius", "linewidth", "head_length", "head_radius")
 
     def __init__(
         self,

--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -277,20 +277,6 @@ class Shape(SceneNode, ABC):
         self._color = tuple(new_color)
 
     # --------------------------------------------------------------------- #
-    # SceneNode properties
-    # These relate to how scene node operates
-
-    @property
-    def T(self) -> ndarray:
-        return self._T
-
-    @T.setter
-    def T(self, T_new: ndarray | SE3) -> None:
-        if isinstance(T_new, SE3):
-            T_new = T_new.A
-        self._T = T_new
-
-    # --------------------------------------------------------------------- #
 
 
 class Axes(Shape):

--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -3,6 +3,7 @@
 @author: Jesse Haviland
 """
 
+from abc import ABC, abstractmethod
 from functools import wraps
 from multiprocessing.sharedctypes import Value
 from spatialgeometry.geom.SceneNode import SceneNode
@@ -63,7 +64,7 @@ except ImportError:  # pragma nocover
 CONST_RX = SE3.Rx(pi / 2).A
 
 
-class Shape(SceneNode):
+class Shape(SceneNode, ABC):
     def __init__(
         self,
         pose: Union[ndarray, SE3] = eye(4),
@@ -155,6 +156,7 @@ class Shape(SceneNode):
         rgb = (array(rgb) * 255).astype(int)
         return int("0x%02x%02x%02x" % (rgb[0], rgb[1], rgb[2]), 16)
 
+    @abstractmethod
     def to_dict(self) -> Dict[str, Any]:
         """
         to_dict() returns the shapes information in dictionary form

--- a/src/spatialgeometry/scene.py
+++ b/src/spatialgeometry/scene.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable, Optional
+from typing import Iterable
 
 import numpy as np
 from numpy.typing import NDArray
@@ -17,7 +17,7 @@ class _Node:
     T: ArrayF64
     wT: ArrayF64
     wq: ArrayF64
-    parent: Optional["_Node"] = None
+    parent: _Node | None = None
     children: list["_Node"] = field(default_factory=list)
 
 
@@ -53,7 +53,7 @@ def _r2q_xyzs(R: ArrayF64) -> ArrayF64:
     return q
 
 
-def _propogate_T(node: _Node, parent_wT: Optional[ArrayF64]) -> None:
+def _propogate_T(node: _Node, parent_wT: ArrayF64 | None) -> None:
     if parent_wT is None:
         node.wT[:] = node.T
     else:
@@ -70,9 +70,9 @@ def node_init(
     T: ArrayF64,
     wT: ArrayF64,
     wq: ArrayF64,
-    parent: Optional[_Node],
+    parent: _Node | None,
     children: Iterable[_Node],
-):
+) -> _Node:
     node = _Node(T=T, wT=wT, wq=wq)
     node.parent = parent
     node.children = list(children)
@@ -86,9 +86,9 @@ def node_init(
 def node_update(
     node: _Node,
     n_children: int,
-    parent: Optional[_Node],
+    parent: _Node | None,
     children: Iterable[_Node],
-):
+) -> None:
     node.parent = parent
     node.children = list(children)
 
@@ -96,11 +96,11 @@ def node_update(
         node.children = node.children[:n_children]
 
 
-def scene_graph_children(node: _Node):
+def scene_graph_children(node: _Node) -> None:
     _propogate_T(node, None)
 
 
-def scene_graph_tree(node: _Node):
+def scene_graph_tree(node: _Node) -> None:
     while node.parent is not None:
         node = node.parent
 

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -294,6 +294,38 @@ class TestShape(unittest.TestCase):
         self.assertEqual(d["radius"], 0.1)
         self.assertEqual(d["linewidth"], 5.0)
 
+    def test_repr_distinguishes_deprecated_alias_from_its_base(self):
+        # Box is a deprecated alias of Cuboid sharing the same stype --
+        # repr must still tell them apart (it used to show "cuboid" for
+        # both, making them indistinguishable).
+        cuboid = gm.Cuboid([1, 2, 3])
+        box = gm.Box([1, 2, 3])
+
+        self.assertTrue(repr(cuboid).startswith("Cuboid("))
+        self.assertTrue(repr(box).startswith("Box("))
+        self.assertNotEqual(repr(cuboid), repr(box))
+
+    def test_repr_is_single_line_and_shows_constructor_params(self):
+        s0 = gm.Cylinder(1.0, 2.0)
+        r = repr(s0)
+
+        self.assertNotIn("\n", r)
+        self.assertEqual(r, "Cylinder(radius=1.0, length=2.0, pose='t = 0, 0, 0; rpy/zyx = 0°, 0°, 0°')")
+
+    def test_str_is_single_line(self):
+        s0 = gm.Cuboid([1, 1, 1], pose=sm.SE3.Trans(1, 2, 3))
+        s = str(s0)
+
+        self.assertNotIn("\n", s)
+        self.assertEqual(s, "Cuboid at t = 1, 2, 3; rpy/zyx = 0°, 0°, 0°")
+
+    def test_scene_group_repr_and_str(self):
+        group = gm.SceneGroup()
+        group.append(gm.Sphere(1.0))
+
+        self.assertEqual(repr(group), f"SceneGroup([{gm.Sphere(1.0)!r}])")
+        self.assertTrue(str(group).startswith("SceneGroup at "))
+
 
 if __name__ == "__main__":  # pragma nocover
     unittest.main()

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -166,12 +166,12 @@ class TestShape(unittest.TestCase):
         self.assertEqual(s0.color, (1.0, 1.0, 1.0, 1.0))
 
     def test_shape_wt(self):
-        s0 = gm.Shape()
+        s0 = gm.Axes(1.0)
         s0.wT = np.eye(4)
         nt.assert_almost_equal(np.eye(4), s0.wT)
 
     def test_collision_shape_wt(self):
-        s0 = gm.CollisionShape()
+        s0 = gm.Cuboid([1, 1, 1])
         s0.wT = np.eye(4)
         nt.assert_almost_equal(np.eye(4), s0.wT)
 

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -175,6 +175,19 @@ class TestShape(unittest.TestCase):
         s0.wT = np.eye(4)
         nt.assert_almost_equal(np.eye(4), s0.wT)
 
+    def test_set_T_on_parented_shape(self):
+        # Regression test: setting T on a shape that already has a
+        # scene_parent used to raise AttributeError -- SceneNode._T's
+        # setter referenced self.parent.wT, neither of which exist.
+        parent = gm.Cuboid([1, 1, 1], pose=sm.SE3.Trans(1, 0, 0))
+        child = gm.Cuboid([1, 1, 1])
+        parent.attach(child)
+
+        child.T = sm.SE3.Trans(0, 2, 0)
+
+        expected = sm.SE3.Trans(1, 0, 0).A @ sm.SE3.Trans(0, 2, 0).A
+        nt.assert_almost_equal(child._wT, expected)
+
     def test_mesh_collision_false(self):
         s0 = gm.Mesh("test.stl", collision=False)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary

A batch of independent code-quality fixes found while reviewing `geom/`, each its own commit:

- **Make `Shape`/`CollisionShape` abstract** — neither was meant to be instantiated directly; `Shape.to_dict` and `CollisionShape._init_coal` are now `@abstractmethod` (every concrete shape already overrides both).
- **Modernize type hints** across `scene.py`/`SceneNode.py`/`SceneGroup.py`/`Shape.py`/`CollisionShape.py` — `Union`/`List`/`Dict`/`Tuple`/`Optional` → `X | Y`/`list`/`dict`/`tuple`, and fill in hints that were simply missing on several public constructors/properties. Also fixes a real bug found along the way: `SceneNode.scene_parent` was annotated `Type["SceneNode"]` (the class itself) instead of an instance.
- **Move `T` property from `Shape` to `SceneNode`** — it was a thin, non-Shape-specific wrapper around `SceneNode`'s own `_T`; moving it up means `SceneGroup` (and any future `SceneNode` subclass) gets the same convenient, `SE3`-accepting pose property that only `Shape` had before.
- **Fix `SceneNode._T`'s setter** — it referenced `self.parent.wT`, neither of which exist (`_scene_parent` and `_wT` are the real names), so setting a parented node's pose raised `AttributeError`. Includes a regression test; this path had no coverage before.
- **Fix `__repr__`/`__str__`** — the old `__repr__` showed only `stype` + translation, so `Box` (a deprecated alias of `Cuboid`) was indistinguishable from `Cuboid`, and it was multi-line (breaks badly inside a list or `SceneGroup`). Replaced with a single-line, constructor-style repr (`Cylinder(radius=1.0, length=2.0, pose='t = ...')`) using `SE3.strline()` for the pose. `__str__` moved up to `SceneNode` as a clean one-liner, benefiting `SceneGroup` too.
- **Expose `__version__`** — the other toolbox packages (`spatialmath-python`, `robotics-toolbox-python`, `bdsim`, `machinevision-toolbox-python`) all do via `importlib.metadata.version()`; this was the one holdout.

## Test plan

- [x] Full test suite passes (`pytest tests/`) — 99 passed (was 94 at the start; added regression tests for the `_T` setter bug and the repr/str fixes, none of which had coverage before)
- [x] Verified `Shape()`/`CollisionShape()` now raise `TypeError` as expected, all concrete subclasses still instantiate
- [x] Verified `Box`/`Cuboid` reprs are now distinct, and `SceneGroup.T`/`repr`/`str` all work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)