### PR TITLE
fix: SceneGroup list mutators didn't wire scene_parent

### DIFF
--- a/src/spatialgeometry/geom/SceneGroup.py
+++ b/src/spatialgeometry/geom/SceneGroup.py
@@ -6,16 +6,98 @@
 from __future__ import annotations
 
 from collections import UserList
+from collections.abc import Iterable
 
 from spatialgeometry.geom.SceneNode import SceneNode
 
 
 class SceneGroup(SceneNode, UserList):
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+    """
+    An ordered, list-like collection of :class:`SceneNode` objects.
+
+    A :class:`SceneGroup` is itself a :class:`SceneNode` so its elements can be
+    collectively, parented or nested like any other node in the scene graph. This class
+    inherits from :class:`collections.UserList` so it behaves like a Python list, but it
+    is not a subclass of :class:`list` so it can be subclassed itself.
+
+    Every element's ``scene_parent`` is kept pointing at the group -- adding an
+    element (via the constructor, ``append``, ``extend``, ``insert``, or item
+    assignment) sets it, and removing one (``remove``, ``pop``, ``clear``,
+    ``del``) clears it back to ``None``. This is what makes moving the group
+    move its elements with it.
+
+    .. runblock:: pycon
+
+        >>> from spatialgeometry import SceneGroup, Cuboid, Sphere
+        >>> from spatialmath import SE3
+        >>> group = SceneGroup()
+        >>> print(len(group))
+        >>> group.append(Cuboid([1,2,3]))
+        >>> group.append(Sphere(1, pose=SE3.Trans(1,0,0)))
+        >>> print(len(group))
+    """
+
+    def __init__(
+        self, initlist: Iterable[SceneNode] | None = None, **kwargs
+    ) -> None:
+        super().__init__(
+            scene_children=list(initlist) if initlist is not None else None,
+            **kwargs,
+        )
 
     def __getitem__(self, i: int) -> SceneNode:
         return self._scene_children[i]
+
+    def __setitem__(self, i: int, item: SceneNode) -> None:
+        if isinstance(i, slice):
+            raise NotImplementedError(
+                "Slice assignment is not supported for SceneGroup"
+            )
+        old = self._scene_children[i]
+        self.remove(old)
+        self.insert(i, item)
+
+    def __delitem__(self, i: int | slice) -> None:
+        if isinstance(i, slice):
+            for item in list(self._scene_children[i]):
+                self.remove(item)
+        else:
+            self.remove(self._scene_children[i])
+
+    def append(self, item: SceneNode) -> None:
+        """Add ``item`` to the end of the group and set its ``scene_parent``
+        to this group."""
+        item.scene_parent = self
+
+    def extend(self, other: Iterable[SceneNode]) -> None:
+        """Add every element of ``other`` to the end of the group, setting
+        each one's ``scene_parent`` to this group."""
+        for item in other:
+            self.append(item)
+
+    def insert(self, i: int, item: SceneNode) -> None:
+        """Insert ``item`` at position ``i`` and set its ``scene_parent`` to
+        this group."""
+        item.scene_parent = self
+        self._scene_children.insert(i, self._scene_children.pop())
+
+    def remove(self, item: SceneNode) -> None:
+        """Remove ``item`` from the group and clear its ``scene_parent``."""
+        self._remove_scene_child(item)
+        item._scene_parent = None
+
+    def pop(self, i: int = -1) -> SceneNode:
+        """Remove and return the element at position ``i`` (default: the
+        last one), clearing its ``scene_parent``."""
+        item = self._scene_children[i]
+        self.remove(item)
+        return item
+
+    def clear(self) -> None:
+        """Remove every element from the group, clearing each one's
+        ``scene_parent``."""
+        for item in list(self._scene_children):
+            self.remove(item)
 
     @property
     def data(self) -> list[SceneNode]:

--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -223,6 +223,17 @@ class SceneNode:
         # Update c
         self.__update_c()
 
+    def _remove_scene_child(self, child: SceneNode) -> None:
+        """
+        Removes a child from this object, does NOT clear the
+        child's own scene_parent reference
+
+        """
+        self.scene_children.remove(child)
+
+        # Update c
+        self.__update_c()
+
     # --------------------------------------------------------------------- #
 
     @property

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -343,6 +343,71 @@ class TestShape(unittest.TestCase):
         self.assertEqual(repr(group), f"SceneGroup([{gm.Sphere(1.0)!r}])")
         self.assertTrue(str(group).startswith("SceneGroup at "))
 
+    def test_scene_group_constructor_accepts_initial_elements(self):
+        cube = gm.Cuboid([1, 1, 1])
+        sphere = gm.Sphere(1.0)
+        group = gm.SceneGroup([cube, sphere])
+
+        self.assertEqual(len(group), 2)
+        self.assertIs(cube.scene_parent, group)
+        self.assertIs(sphere.scene_parent, group)
+
+    def test_scene_group_mutators_set_and_clear_scene_parent(self):
+        group = gm.SceneGroup()
+
+        box = gm.Cuboid([1, 1, 1])
+        group.append(box)
+        self.assertIs(box.scene_parent, group)
+
+        extra = gm.Sphere(0.5)
+        group.extend([extra])
+        self.assertIs(extra.scene_parent, group)
+
+        mid = gm.Sphere(0.3)
+        group.insert(1, mid)
+        self.assertEqual(list(group), [box, mid, extra])
+        self.assertIs(mid.scene_parent, group)
+
+        group.remove(box)
+        self.assertIsNone(box.scene_parent)
+        self.assertEqual(len(group), 2)
+
+        popped = group.pop()
+        self.assertIs(popped, extra)
+        self.assertIsNone(popped.scene_parent)
+
+        group.clear()
+        self.assertEqual(len(group), 0)
+
+    def test_scene_group_setitem_and_delitem_set_and_clear_scene_parent(self):
+        group = gm.SceneGroup([gm.Cuboid([1, 1, 1]), gm.Sphere(1.0)])
+        old_item = group[0]
+        new_item = gm.Sphere(2.0)
+
+        group[0] = new_item
+        self.assertIs(group[0], new_item)
+        self.assertIs(new_item.scene_parent, group)
+        self.assertIsNone(old_item.scene_parent)
+
+        del group[0]
+        self.assertEqual(len(group), 1)
+
+    def test_scene_group_scene_parent_does_not_flatten_its_elements(self):
+        # Setting a SceneGroup's own scene_parent should only affect the
+        # group itself -- its own elements must stay its elements, not get
+        # reparented to the new parent too.
+        parent = gm.Cuboid([1, 1, 1])
+        group = gm.SceneGroup([gm.Cuboid([1, 1, 1])])
+
+        group.scene_parent = parent
+        self.assertIs(group.scene_parent, parent)
+        self.assertEqual(len(group), 1)
+
+        parent.T = sm.SE3(5, 0, 0)
+        parent._propogate_scene_tree()
+        nt.assert_almost_equal(group._wT[:3, 3], [5, 0, 0])
+        nt.assert_almost_equal(group[0]._wT[:3, 3], [5, 0, 0])
+
     def test_Path_defaults(self):
         # points is accepted/stored as 3xN (this ecosystem's own point-set
         # convention), but the wire format transposes to a flat N x 3 list

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -411,6 +411,73 @@ class TestClosestChain:
         assert (d, p1, p2) == (None, None, None)
 
 
+# ── SceneGroup collision (first-principles, SG only) ────────────────────────
+#
+# Not "do pose values propagate" (see TestShape's scene-graph tests) but "does
+# Coal-backed iscollided()/closest_point() give correct, currently-live
+# results for elements inside a SceneGroup built via the normal list
+# interface (append()), not just via scene_children= at construction time."
+# This is exactly the code path that had a scene_parent wiring bug before
+# this fix -- append() only mutated the raw list, never wired the element's
+# own scene_parent or refreshed the group's cached scene-graph children, so a
+# moved/reparented group's elements kept reporting stale collision geometry.
+
+@skip_no_collision_checking
+class TestSceneGroupCollision:
+    def test_append_built_group_tracks_reparenting(self):
+        # Parent established BEFORE the append, not after -- appending to an
+        # already-parented group is the scenario that actually exposes a
+        # stale/never-refreshed scene-graph cache; appending before parenting
+        # would incidentally get swept up by the group's own
+        # scene_parent-setter refresh regardless of whether append() itself
+        # is wired correctly, silently defeating this as a regression test.
+        anchor = cuboid_at(0.1, 0.1, 0.1)
+        group = gm.SceneGroup()
+        group.scene_parent = anchor
+        col = Cuboid([1, 1, 1])
+        group.append(col)
+
+        probe = cuboid_at(1, 1, 1, x=13)
+
+        # col at world x=0 (identity offset through group -> anchor): faces
+        # at 0.5 and 12.5 -> gap 12.0
+        d0, _, _ = col.closest_point(probe, BIG)
+        assert d0 == pytest.approx(12.0, abs=1e-6)
+
+        anchor.T = SE3(10, 0, 0)
+        anchor._propogate_scene_tree()
+
+        # col now at world x=10: faces at 10.5 and 12.5 -> gap 2.0. If the
+        # group's append() hadn't wired col into the propagated scene graph,
+        # col._wT would still read as it did before the move and this would
+        # incorrectly still be 12.0.
+        d1, _, _ = col.closest_point(probe, BIG)
+        assert d1 == pytest.approx(2.0, abs=1e-6)
+
+    def test_multiple_appended_elements_all_tracked_independently(self):
+        anchor = cuboid_at(0.1, 0.1, 0.1)
+        group = gm.SceneGroup()
+        group.scene_parent = anchor
+        c1 = Cuboid([1, 1, 1])              # local offset 0
+        c2 = cuboid_at(1, 1, 1, x=5)         # local offset +5
+        group.append(c1)
+        group.append(c2)
+
+        anchor.T = SE3(20, 0, 0)
+        anchor._propogate_scene_tree()
+
+        # c1 -> world x=20, c2 -> world x=25 (its own local +5 composed on
+        # top of anchor's move)
+        assert c1.iscollided(cuboid_at(1, 1, 1, x=20))
+        assert c2.iscollided(cuboid_at(1, 1, 1, x=25))
+
+        # cross-check both directions, so a bug that only wires the *last*
+        # (or *first*) appended element can't hide behind a single passing
+        # assertion above
+        assert not c1.iscollided(cuboid_at(1, 1, 1, x=25))
+        assert not c2.iscollided(cuboid_at(1, 1, 1, x=20))
+
+
 # ── to_dict ───────────────────────────────────────────────────────────────────
 
 class TestToDict:


### PR DESCRIPTION
## Summary
- `SceneGroup.data` is a read-only property returning the live `_scene_children` list, so `UserList`'s inherited `append`/`extend`/`insert`/`remove`/`pop`/`clear`/`__setitem__`/`__delitem__` mutated that list directly without going through the `scene_parent` wiring -- elements added via these never got `scene_parent` set (only `_scene_children` grew).
- The constructor couldn't accept an initial list at all (`SceneGroup([a, b])` raised `TypeError`), even though `SceneNode.__init__` already supports this correctly via its existing `scene_children=` kwarg -- it just wasn't exposed through `SceneGroup`'s own signature.
- Fix: override the list mutators to route through `scene_parent` (add) and a new `SceneNode._remove_scene_child()` helper, symmetric to the existing `_update_scene_children` (remove), so every mutation path behaves consistently, not just `append`.

## Test plan
- [x] All 105 pre-existing tests pass
- [x] Added 4 new tests covering: constructor with initial list, all mutators (`append`/`extend`/`insert`/`remove`/`pop`/`clear`), `__setitem__`/`__delitem__`, and that setting a `SceneGroup`'s own `scene_parent` doesn't flatten its contents (verified with an actual pose-propagation cascade check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)