### PR TITLE
feat: Mesh accepts a scalar scale, and a y_up param for Y-up meshes

### DIFF
--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -103,23 +103,66 @@ class CollisionShape(Shape):
         return self.iscollided(shape)
 
 
+# =====================================================================
+# LOUD WARNING -- read this before touching y_up.
+#
+# This rotation MUST stay bit-for-bit equivalent to the y_up correction
+# applied in Swift's shapes.js (search "y_up" there -- applied via
+# geometry.rotateX() on the loaded THREE.Geometry, once, at load time).
+#
+# These two implementations live in different languages in different
+# repos and NOTHING enforces they agree. If they ever diverge, there is
+# no test or type checker that will catch it -- collision geometry will
+# just silently stop matching what's actually rendered. If you change
+# one side, you MUST change the other, in the same PR pair.
+#
+# What it does: a mesh authored with +Y as "up" is reinterpreted as if
+# it were authored +Z "up" (this ecosystem's convention). Equivalent to
+# Rx(+90 degrees) applied to the mesh's own local vertex data:
+# +Y -> +Z, +Z -> -Y, +X unchanged. Baked into the static vertex data
+# itself (here, once, at load time) rather than into the shape's live
+# pose -- so it survives re-posing/animation, same reasoning as Swift's
+# existing Cylinder axis correction (three.js's CylinderGeometry
+# defaults to axis-along-Y; shapes.js corrects it the same way).
+# =====================================================================
+_Y_UP_TO_Z_UP = np.array(
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, -1.0, 0.0],
+    ]
+)
+
+
 class Mesh(CollisionShape):
     """
     A mesh object described by an STL, OBJ, or DAE file.
 
     :param filename: Absolute path to the mesh file.
-    :param scale: Scale factors along XYZ axes (default [1, 1, 1]).
+    :param scale: Scale factor(s) along XYZ axes (default [1, 1, 1]). A
+        single number applies the same scale to all three axes.
+    :param y_up: Set True if the mesh file was authored with +Y as the
+        "up" axis -- a common convention in general 3D/graphics tooling --
+        rather than this ecosystem's +Z-up convention. See the
+        ``_Y_UP_TO_Z_UP`` comment in this module for the full story; the
+        short version is that Swift applies the matching correction on
+        its own side, and the two must be kept in sync.
     :param collision: Whether this shape participates in collision checking.
     """
 
-    _repr_params = ("filename", "scale")
+    _repr_params = ("filename", "scale", "y_up")
 
     def __init__(
-        self, filename: str | None = None, scale: ArrayLike = [1, 1, 1], **kwargs
+        self,
+        filename: str | None = None,
+        scale: ArrayLike | float = [1, 1, 1],
+        y_up: bool = False,
+        **kwargs,
     ) -> None:
         super().__init__(stype="mesh", **kwargs)
         self.filename = filename
         self.scale = scale
+        self.y_up = y_up
 
     def _init_coal(self) -> None:
         if not self.collision:
@@ -135,7 +178,12 @@ class Mesh(CollisionShape):
             )
 
         mesh = trimesh.load(self.filename, force="mesh")
-        vertices = (mesh.vertices * self.scale).astype(np.float64, order="C")
+        vertices = mesh.vertices
+        if self.y_up:
+            # See the LOUD WARNING on _Y_UP_TO_Z_UP above -- Swift's
+            # shapes.js must apply the identical correction.
+            vertices = vertices @ _Y_UP_TO_Z_UP
+        vertices = (vertices * self.scale).astype(np.float64, order="C")
         triangles = mesh.faces.astype(np.int64, order="C")
 
         bvh = _coal.BVHModelOBBRSS()
@@ -153,9 +201,12 @@ class Mesh(CollisionShape):
 
     @scale.setter
     @update
-    def scale(self, value: ArrayLike) -> None:
-        value = getvector(value if value is not None else [1, 1, 1], 3)
-        self._scale = np.array(value)
+    def scale(self, value: ArrayLike | float | None) -> None:
+        if value is None:
+            value = [1, 1, 1]
+        elif np.isscalar(value):
+            value = [value, value, value]
+        self._scale = np.array(getvector(value, 3))
 
     @property
     def filename(self) -> str | None:
@@ -166,10 +217,30 @@ class Mesh(CollisionShape):
     def filename(self, value: str | None) -> None:
         self._filename = value
 
+    @property
+    def y_up(self) -> bool:
+        """
+        True if this mesh file was authored with +Y as "up" and needs
+        the +Y -> +Z correction applied. See the ``_Y_UP_TO_Z_UP`` LOUD
+        WARNING comment above ``Mesh`` -- Swift applies the matching
+        correction on its own side, and the two must stay in sync.
+
+        This is a read/write property.
+
+        :rtype: bool
+        """
+        return self._y_up
+
+    @y_up.setter
+    @update
+    def y_up(self, value: bool) -> None:
+        self._y_up = bool(value)
+
     def to_dict(self) -> dict[str, Any]:
         shape = super().to_dict()
         shape["filename"] = self.filename
         shape["scale"] = self.scale.tolist()
+        shape["y_up"] = self.y_up
         return shape
 
 

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -210,12 +210,21 @@ class TestShape(unittest.TestCase):
         with self.assertRaises(ValueError):
             s0._init_coal()
 
+    def test_mesh_scalar_scale(self):
+        s0 = gm.Mesh("test.stl", scale=2.0)
+        nt.assert_almost_equal(s0.scale, [2.0, 2.0, 2.0])
+
+    def test_mesh_list_scale_still_works(self):
+        s0 = gm.Mesh("test.stl", scale=[1.0, 2.0, 3.0])
+        nt.assert_almost_equal(s0.scale, [1.0, 2.0, 3.0])
+
     def test_mesh2(self):
         s0 = gm.Mesh("test.stl")
 
         ans = {
             "stype": "mesh",
             "scale": [1.0, 1.0, 1.0],
+            "y_up": False,
             "filename": "test.stl",
             "t": [0.0, 0.0, 0.0],
             "q": [0.0, 0.0, 0.0, 1],

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -254,6 +254,29 @@ class TestMeshDistance:
         assert m0.iscollided(m1)
         assert not m0.iscollided(m2)
 
+    def test_mesh_y_up_rotates_collision_geometry(self, tmp_path):
+        # An asymmetric box (not a cube) so an axis mix-up is actually
+        # detectable -- swaps Y and Z, matching the +Y-up -> +Z-up
+        # correction (see the LOUD WARNING on CollisionShape._Y_UP_TO_Z_UP,
+        # which must stay identical to Swift's shapes.js correction).
+        import trimesh
+
+        path = tmp_path / "asym.stl"
+        trimesh.creation.box(extents=[1, 2, 3]).export(str(path))
+
+        m0 = gm.Mesh(str(path))
+        m0._ensure_coal()
+        m0.co.computeAABB()
+        extent0 = m0.co.getAABB().max_ - m0.co.getAABB().min_
+
+        m1 = gm.Mesh(str(path), y_up=True)
+        m1._ensure_coal()
+        m1.co.computeAABB()
+        extent1 = m1.co.getAABB().max_ - m1.co.getAABB().min_
+
+        np.testing.assert_allclose(extent0, [1.0, 2.0, 3.0], atol=1e-6)
+        np.testing.assert_allclose(extent1, [1.0, 3.0, 2.0], atol=1e-6)
+
 
 # ── iscollided ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `Mesh(scale=...)` now accepts a single number (uniform scale on all 3 axes), not just a 3-element list.
- New `Mesh(y_up=True)` param for mesh files authored with +Y as "up" (a common convention in general 3D/graphics tooling) rather than this ecosystem's +Z-up convention. Applies a fixed `Rx(+90deg)` correction to the mesh's own local vertex data before building the Coal BVH.
- The correction is baked into the static vertex data once, at load time, rather than into the shape's live pose -- so it survives re-posing/animation correctly (same reasoning as an existing three.js axis-convention fix already used for `Cylinder` on the Swift side).

**Companion PR:** jhavl/swift#110 applies the identical correction to the rendered geometry. See the `LOUD WARNING` comment on `_Y_UP_TO_Z_UP` in `CollisionShape.py` -- the two implementations must be kept in sync (different languages, different repos, nothing enforces agreement automatically).

## Test plan
- [x] All existing tests pass (with `test_mesh2`'s expected `to_dict()` updated for the new `y_up` field)
- [x] Added `test_mesh_scalar_scale` / `test_mesh_list_scale_still_works`
- [x] Added `test_mesh_y_up_rotates_collision_geometry` -- uses an asymmetric `[1, 2, 3]` box (not a cube, so an axis mix-up is actually detectable) and verifies the Coal collision AABB extent goes from `[1, 2, 3]` to `[1, 3, 2]` under `y_up=True`, matching the expected Y/Z swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)