### PR TITLE
fix: Cylinder collision geometry was half its documented length

### DIFF
--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -194,8 +194,12 @@ class Cylinder(CollisionShape):
             raise ValueError(
                 "This shape has collision=False and cannot be used as a collision object"
             )
-        # Coal Cylinder(radius, halfLength)
-        geom = _coal.Cylinder(self.radius, self.length / 2.0)
+        # Coal Cylinder(radius, length) takes full length, not half length
+        # -- verified directly (coal.Cylinder(1.0, 10.0).halfLength == 5.0).
+        # Passing length/2.0 here (as this line used to) silently built a
+        # collision cylinder half as tall as gm.Cylinder's own documented
+        # "length: Total length in metres" contract promises.
+        geom = _coal.Cylinder(self.radius, self.length)
         self.co = _coal.CollisionObject(geom)
         self._cinit = True
 

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -188,6 +188,25 @@ class TestCylinder:
             cylinder_at(1.0, 2.0, x=1.0), inf_dist=BIG)
         assert d < 0
 
+    def test_separated_axially(self):
+        # Every test above only probes radially (offset along X) -- none of
+        # them exercise the cylinder's own axis (Z) at all, which is
+        # exactly how a "length was silently halved" bug in _init_coal()
+        # went undetected. length=4 -> each cylinder spans z in [-2, 2]
+        # locally; centres 5 apart along Z -> gap = (5 - 2) - 2 = 1.0.
+        d, _, _ = cylinder_at(1.0, 4.0, z=0.0).closest_point(
+            cylinder_at(1.0, 4.0, z=5.0), inf_dist=BIG)
+        assert d == pytest.approx(1.0, abs=1e-5)
+
+    def test_full_length_not_halved(self):
+        # Direct check on the collision geometry itself: a length=4
+        # cylinder's collision AABB must be 4 units tall, not 2.
+        c = cylinder_at(1.0, 4.0)
+        c._ensure_coal()
+        c.co.computeAABB()
+        aabb = c.co.getAABB()
+        assert (aabb.max_[2] - aabb.min_[2]) == pytest.approx(4.0, abs=1e-6)
+
 
 # ── Mixed shape pairs ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `Cylinder._init_coal()` called `_coal.Cylinder(self.radius, self.length / 2.0)`, on a comment claiming Coal's constructor takes `(radius, halfLength)`. It doesn't -- verified directly (`coal.Cylinder(1.0, 10.0).halfLength` reads back as `5.0`, and the AABB confirms it): Coal's second constructor argument is the **full** length, and `halfLength` is a derived read-only property, not an input.
- So `gm.Cylinder(radius=1, length=4)`'s actual **collision** geometry was only 2 units tall -- half of what `Cylinder`'s own docstring (`length: Total length in metres`) promises, and inconsistent with every other shape (nothing else in this API takes a half-dimension, per discussion).
- Fix: pass `self.length` straight through.

Found while cross-checking the bounding-box feature in #24 against Coal's own `computeLocalAABB()` -- not part of that PR, kept as its own fix per the usual one-branch-per-change-set convention here.

## Why this went undetected
Every existing `TestCylinder` test only probes radially (cylinders offset along X) -- none exercise the cylinder's own axis (Z) at all.

## Test plan
- [x] Added `test_separated_axially` (cylinders offset along Z, `closest_point()`) and `test_full_length_not_halved` (direct check on the collision geometry's own AABB height)
- [x] Verified both new tests fail against the old code (`2.0` instead of the expected `4.0`) and pass against the fix
- [x] Full suite passes (107 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)