### PR TITLE
fix: reject scene_parent assignments that would create a cycle

### DIFF
--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -165,14 +165,11 @@ class SceneNode:
         the parents child
 
         """
-        # Set our parent
-        self._scene_parent = parent
+        # Set our parent (also validates this won't create a cycle)
+        self._update_scene_parent(parent)
 
         # Update our parents children
         parent._update_scene_children(self)
-
-        # Update c
-        self.__update_c()
 
     def _update_scene_parent(self, parent: SceneNode) -> None:
         """
@@ -180,6 +177,26 @@ class SceneNode:
         the parents child
 
         """
+        # A node can't become its own ancestor -- walk the new parent's own
+        # chain of parents; if self shows up (or parent is self), this
+        # reparenting would create a cycle. Nothing downstream checks for
+        # this: _propogate_scene_tree()'s root-finding walk (SceneNode.py,
+        # also mirrored in scene.py and the compiled scene_nb.cpp) has no
+        # cycle detection of its own -- a parent-chain cycle makes it spin
+        # forever (an infinite loop, not a catchable exception), and
+        # Swift's env.step() calls it every step. O(depth) per call here;
+        # fine for how small these graphs actually get, see tech-debt
+        # issue for a cheaper approach if that ever stops being true.
+        ancestor = parent
+        while ancestor is not None:
+            if ancestor is self:
+                raise ValueError(
+                    f"Cannot set {self!r}'s scene_parent to {parent!r} -- "
+                    f"{parent!r} is already a descendant of {self!r}, this "
+                    "would create a cycle in the scene graph"
+                )
+            ancestor = ancestor.scene_parent
+
         self._scene_parent = parent
 
         # Update c

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -205,6 +205,41 @@ class TestShape(unittest.TestCase):
         expected = sm.SE3.Trans(1, 0, 0).A @ sm.SE3.Trans(0, 2, 0).A
         nt.assert_almost_equal(child._wT, expected)
 
+    def test_scene_parent_rejects_self_parenting(self):
+        a = gm.Cuboid([1, 1, 1])
+        with self.assertRaises(ValueError):
+            a.scene_parent = a
+
+    def test_scene_parent_rejects_two_node_cycle(self):
+        a = gm.Cuboid([1, 1, 1])
+        b = gm.Cuboid([1, 1, 1])
+        b.scene_parent = a
+        with self.assertRaises(ValueError):
+            a.scene_parent = b
+
+    def test_scene_parent_rejects_longer_cycle(self):
+        x = gm.Cuboid([1, 1, 1])
+        y = gm.Cuboid([1, 1, 1])
+        z = gm.Cuboid([1, 1, 1])
+        y.scene_parent = x
+        z.scene_parent = y
+        with self.assertRaises(ValueError):
+            x.scene_parent = z
+
+    def test_attach_to_rejects_cycle(self):
+        # attach_to() goes through scene_parent -- same protection applies.
+        m = gm.Cuboid([1, 1, 1])
+        n = gm.Cuboid([1, 1, 1])
+        n.attach_to(m)
+        with self.assertRaises(ValueError):
+            m.attach_to(n)
+
+    def test_valid_reparenting_still_works(self):
+        p = gm.Cuboid([1, 1, 1])
+        q = gm.Cuboid([1, 1, 1])
+        q.scene_parent = p
+        self.assertIs(q.scene_parent, p)
+
     def test_mesh_collision_false(self):
         s0 = gm.Mesh("test.stl", collision=False)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- Nothing previously stopped `a.scene_parent = b; b.scene_parent = a` (or a self-loop `x.scene_parent = x`, or a longer cycle) -- every entry point (`scene_parent`'s setter, `attach_to()`, `scene_children=`'s per-child loop, `attach()`) just assigned pointers/appended to lists with no validation.
- Consequence: `_propogate_scene_tree()`'s root-finding walk (mirrored identically in `scene.py`'s pure-Python fallback and the compiled `scene_nb.cpp`) has no cycle detection of its own -- a parent-chain cycle makes it spin forever (an infinite loop, not a catchable exception), and Swift's `env.step()` calls it every step.
- Consolidated `scene_parent`'s setter to delegate to the existing `_update_scene_parent()` (previously two copies of the same `self._scene_parent = parent` line) and added the cycle check there -- the one place every reparenting path now funnels through, so `attach()`/`attach_to()`/`scene_children=` are covered for free, no special-casing needed.
- `O(depth)` ancestor walk per reparent call, done eagerly at assignment time rather than cached -- deliberately simple given how small these graphs actually get in practice (fails fast with a clear error right where the mistake was made, rather than a mysterious hang later). Filed #26 to track optimizing this if it's ever actually needed.

## Test plan
- [x] Full suite passes (110 tests, 5 new)
- [x] Added tests: self-parenting, 2-node cycle, 3-node cycle, cycle via `attach_to()`, valid non-cyclic reparenting still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)