### PR TITLE
feat: split trimesh out of collision into its own mesh extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ required there.
 > pip install spatialgeometry trimesh
 > ```
 
+If you don't need collision checking but do want to work with mesh files --
+e.g. `Mesh.corners()`/`bounds()`/`extents()` for a mesh's bounding box, which
+reads the file via [trimesh](https://trimesh.org) but never touches Coal at
+all -- install just that piece:
+
+```shell
+pip install spatialgeometry[mesh]
+```
+
+Unlike `collision`, this works on Windows too: trimesh has no Windows-wheel
+problem of its own, only Coal does.
+
 ### conda / conda-forge
 
 For development, the provided `environment.yml` installs the package in

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -29,6 +29,16 @@ Distance and collision checking need the ``collision`` extra (`Coal
 
     pip install spatialgeometry[collision]
 
+If you don't need collision checking but do want to work with mesh files --
+e.g. :meth:`~spatialgeometry.Mesh.corners`/``bounds``/``extents`` for a
+mesh's bounding box, which reads the file via trimesh but never touches Coal
+at all -- install just that piece::
+
+    pip install spatialgeometry[mesh]
+
+Unlike ``collision``, this works on Windows too: trimesh has no Windows-wheel
+problem of its own, only Coal does.
+
 
 Quick start
 ===========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,14 @@ repository = "https://github.com/jhavl/spatialgeometry"
 
 [project.optional-dependencies]
 
-collision = ["coal; sys_platform != 'win32'", "trimesh", "pycollada"]
+# trimesh has no Windows-wheel problem of its own -- split out from collision
+# so mesh-only functionality (e.g. Mesh.corners()/bounds()/extents(), which
+# needs trimesh to read a mesh file's vertices but never touches Coal at
+# all) doesn't force in coal, which currently has no Windows wheel at all
+# (see coal-library/coal#793).
+mesh = ["trimesh"]
+
+collision = ["spatialgeometry[mesh]", "coal; sys_platform != 'win32'", "pycollada"]
 
 dev = [
     "black",

--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -182,7 +182,8 @@ class Mesh(CollisionShape):
         except ImportError:
             raise ImportError(
                 "The 'trimesh' package is required to compute a Mesh's "
-                "bounding box. Install with:  pip install trimesh"
+                "bounding box. Install with:  pip install spatialgeometry[mesh]"
+                " (or just  pip install trimesh  directly)"
             )
         mesh = trimesh.load(self.filename, force="mesh")
         mn, mx = mesh.bounds

--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -12,7 +12,7 @@ from typing import Any
 import numpy as np
 from spatialmath.base.argcheck import getvector
 from spatialgeometry.geom import Shape
-from spatialgeometry.geom.Shape import ArrayLike, update
+from spatialgeometry.geom.Shape import ArrayLike, aabb_corners, update
 from warnings import warn
 
 # Module-level coal reference — populated on first use, never in Pyodide.
@@ -172,6 +172,22 @@ class Mesh(CollisionShape):
         shape["scale"] = self.scale.tolist()
         return shape
 
+    def _local_corners(self) -> np.ndarray:
+        # Independent of self.collision/_init_coal() -- a mesh's bounding
+        # box is a plain geometric fact, not a collision-only concern, so
+        # this loads via trimesh itself rather than reusing _init_coal()
+        # (which raises ValueError when collision=False).
+        try:
+            import trimesh
+        except ImportError:
+            raise ImportError(
+                "The 'trimesh' package is required to compute a Mesh's "
+                "bounding box. Install with:  pip install trimesh"
+            )
+        mesh = trimesh.load(self.filename, force="mesh")
+        mn, mx = mesh.bounds
+        return aabb_corners(mn * self.scale, mx * self.scale)
+
 
 class Cylinder(CollisionShape):
     """
@@ -223,6 +239,10 @@ class Cylinder(CollisionShape):
         shape["length"] = self.length
         return shape
 
+    def _local_corners(self) -> np.ndarray:
+        r, h = self.radius, self.length / 2.0
+        return aabb_corners([-r, -r, -h], [r, r, h])
+
 
 class Sphere(CollisionShape):
     """
@@ -259,6 +279,10 @@ class Sphere(CollisionShape):
         shape = super().to_dict()
         shape["radius"] = self.radius
         return shape
+
+    def _local_corners(self) -> np.ndarray:
+        r = self.radius
+        return aabb_corners([-r, -r, -r], [r, r, r])
 
 
 class Cuboid(CollisionShape):
@@ -299,6 +323,10 @@ class Cuboid(CollisionShape):
         shape = super().to_dict()
         shape["scale"] = self.scale.tolist()
         return shape
+
+    def _local_corners(self) -> np.ndarray:
+        h = self.scale / 2.0
+        return aabb_corners(-h, h)
 
 
 class Box(Cuboid):

--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -29,6 +29,19 @@ import numpy as np
 
 ArrayLike = list | ndarray | tuple | set
 _mpl = False
+
+
+def aabb_corners(mn: ArrayLike, mx: ArrayLike) -> ndarray:
+    """
+    The 8 corners of the axis-aligned box spanning ``mn`` to ``mx``.
+
+    :param mn: minimum [x, y, z]
+    :param mx: maximum [x, y, z]
+    :rtype: ndarray(3,8)
+    """
+    return np.array(
+        [[x, y, z] for x in (mn[0], mx[0]) for y in (mn[1], mx[1]) for z in (mn[2], mx[2])]
+    ).T
 # _rtb = False
 
 
@@ -291,6 +304,67 @@ class Shape(SceneNode, ABC):
 
         new_color = concatenate([self._color[:3], [alpha]])
         self._color = tuple(new_color)
+
+    # --------------------------------------------------------------------- #
+    # Bounding box
+    #
+    # _local_corners() is the one thing each subclass overrides -- the 8
+    # corners of the shape's own axis-aligned bounding box, in its local
+    # frame (pose ignored). corners()/bounds()/extents() are all derived
+    # from it here, generically, once. Not an @abstractmethod: a shape
+    # that hasn't implemented it yet (e.g. Axes/Arrow/Path, currently)
+    # raises NotImplementedError only if corners() is actually called on
+    # it, rather than making the class impossible to instantiate.
+    # --------------------------------------------------------------------- #
+
+    def _local_corners(self) -> ndarray:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement a bounding box"
+        )
+
+    def corners(self, world: bool = False) -> ndarray:
+        """
+        The 8 corners of this shape's axis-aligned bounding box.
+
+        :param world: If True, apply this shape's current pose and return
+            the axis-aligned envelope of the posed shape (its corners will
+            move as the shape is re-posed, and a rotated shape's envelope
+            is generally larger than its own local box -- this is *not*
+            the shape's true oriented/rotated corners). If False
+            (default), return the corners in the shape's own local frame,
+            independent of pose -- constant unless the shape's own
+            parameters (radius, scale, ...) change.
+
+        :rtype: ndarray(3,8)
+        """
+        c = self._local_corners()
+        if not world:
+            return c
+
+        wc = self._wT[:3, :3] @ c + self._wT[:3, 3:4]
+        return aabb_corners(wc.min(axis=1), wc.max(axis=1))
+
+    def bounds(self, world: bool = False) -> ndarray:
+        """
+        Min/max extent of this shape's axis-aligned bounding box along
+        each axis.
+
+        :param world: See :meth:`corners`.
+        :rtype: ndarray(3,2)
+        """
+        c = self.corners(world=world)
+        return np.column_stack([c.min(axis=1), c.max(axis=1)])
+
+    def extents(self, world: bool = False) -> ndarray:
+        """
+        Dimensions (width, depth, height) of this shape's axis-aligned
+        bounding box.
+
+        :param world: See :meth:`corners`.
+        :rtype: ndarray(3,)
+        """
+        b = self.bounds(world=world)
+        return b[:, 1] - b[:, 0]
 
     # --------------------------------------------------------------------- #
 

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -387,5 +387,76 @@ class TestShape(unittest.TestCase):
         self.assertEqual(s0.to_dict()["points"], [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
 
 
+class TestBoundingBox(unittest.TestCase):
+    def test_cuboid_local_corners_bounds_extents(self):
+        s0 = gm.Cuboid([1, 2, 3])
+        self.assertEqual(s0.corners().shape, (3, 8))
+        nt.assert_almost_equal(s0.bounds(), [[-0.5, 0.5], [-1, 1], [-1.5, 1.5]])
+        nt.assert_almost_equal(s0.extents(), [1, 2, 3])
+
+    def test_sphere_local_extents(self):
+        s0 = gm.Sphere(2.0)
+        nt.assert_almost_equal(s0.extents(), [4, 4, 4])
+
+    def test_cylinder_local_extents(self):
+        # radius=1, length=4 -- axis along Z (see Cylinder's own docstring)
+        s0 = gm.Cylinder(1.0, 4.0)
+        nt.assert_almost_equal(s0.extents(), [2, 2, 4])
+
+    def test_local_extents_are_pose_independent(self):
+        # Rotating a shape must not change its own local extents -- that's
+        # the whole distinction between world=False (default) and
+        # world=True.
+        s0 = gm.Cuboid([1, 2, 3], pose=sm.SE3.Rz(45, unit="deg"))
+        nt.assert_almost_equal(s0.extents(), [1, 2, 3])
+
+    def test_world_extents_reflect_current_pose(self):
+        # A 1x2x3 cuboid rotated 45 degrees about Z has a larger axis-
+        # aligned footprint in x/y, unchanged in z.
+        s0 = gm.Cuboid([1, 2, 3], pose=sm.SE3.Rz(45, unit="deg"))
+        world_extents = s0.extents(world=True)
+        self.assertGreater(world_extents[0], 1)
+        self.assertGreater(world_extents[1], 2)
+        nt.assert_almost_equal(world_extents[2], 3)
+
+    def test_world_corners_shape(self):
+        s0 = gm.Cuboid([1, 2, 3], pose=sm.SE3.Rz(45, unit="deg") * sm.SE3.Trans(5, 0, 0))
+        self.assertEqual(s0.corners(world=True).shape, (3, 8))
+
+    def test_unimplemented_shape_raises_not_implemented(self):
+        # Axes/Arrow/Path don't implement _local_corners() yet -- corners()
+        # must fail loudly, not silently return a wrong value.
+        s0 = gm.Axes(1.0)
+        with self.assertRaises(NotImplementedError):
+            s0.corners()
+
+    def test_mesh_extents(self):
+        import tempfile
+        import trimesh
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = f"{tmp}/asym.stl"
+            trimesh.creation.box(extents=[1, 2, 3]).export(path)
+
+            s0 = gm.Mesh(path)
+            nt.assert_almost_equal(s0.extents(), [1, 2, 3], decimal=6)
+
+            s1 = gm.Mesh(path, scale=[2, 2, 2])
+            nt.assert_almost_equal(s1.extents(), [2, 4, 6], decimal=6)
+
+    def test_mesh_extents_independent_of_collision_flag(self):
+        # Unlike _init_coal(), the bounding box is a plain geometric fact
+        # and must work even when collision=False.
+        import tempfile
+        import trimesh
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = f"{tmp}/box.stl"
+            trimesh.creation.box(extents=[1, 1, 1]).export(path)
+
+            s0 = gm.Mesh(path, collision=False)
+            nt.assert_almost_equal(s0.extents(), [1, 1, 1], decimal=6)
+
+
 if __name__ == "__main__":  # pragma nocover
     unittest.main()


### PR DESCRIPTION
## Summary
**Stacks on #24** (`Shape.corners()`/`bounds()`/`extents()`) -- this extra split exists specifically for that feature. Since GitHub doesn't support a PR base branch that only exists on a fork, this is based against `main` rather than `feat/shape-bounding-box` directly, so the diff below includes #24's changes too -- the only new commit here is c75e7c1 ("split trimesh out of collision into its own mesh extra"). Please review/merge #24 first; happy to rebase this once that lands if the diff needs cleaning up.

- `trimesh` has no Windows-wheel problem of its own -- only Coal does (see coal-library/coal#793, the Windows-wheel thread from earlier this week). Bundling it into `collision` meant mesh-only functionality that needs `trimesh` but never touches Coal (`Mesh.corners()`/`bounds()`/`extents()` from #24) was unreachable via pip on Windows for no real reason.
- New `mesh` extra: `mesh = ["trimesh"]`. `collision` now depends on it transitively: `collision = ["spatialgeometry[mesh]", "coal; sys_platform != 'win32'", "pycollada"]` -- nothing changes for existing `collision` users, they still get `trimesh` the same as before.
- Updated `Mesh`'s bounding-box `ImportError` to point at the new extra (`pip install spatialgeometry[mesh]`) instead of just bare `pip install trimesh`.
- Updated install instructions in `README.md` and `intro.rst` to mention the new extra, explicitly noting it works on Windows unlike `collision`.

## Test plan
- [x] `pyproject.toml` parses correctly, `mesh`/`collision` extras resolve as expected (verified via `tomllib`)
- [x] Verified the updated `ImportError` message text directly (simulated `trimesh` missing)
- [x] Full test suite passes (114 tests)
- [x] Docs build cleanly, new `:meth:` cross-reference in `intro.rst` resolves with no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)