### PR TITLE
feat: repr() now shows color, and opacity when not fully opaque

### DIFF
--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -200,6 +200,16 @@ class Shape(SceneNode, ABC):
             if isinstance(value, ndarray):
                 value = value.tolist()
             args.append(f"{name}={value!r}")
+
+        # float(...) here, not just tuple(self.color[:3]) -- self._color's
+        # elements are sometimes numpy.float64 (e.g. after color=[...] with
+        # a list/array input), which reprs as "np.float64(1.0)" instead of
+        # a plain "1.0". Harmless for JSON (float64 genuinely subclasses
+        # float, unlike int64), but ugly here specifically.
+        args.append(f"color={tuple(float(c) for c in self.color[:3])!r}")
+        if self.color[3] != 1.0:
+            args.append(f"opacity={float(self.color[3])!r}")
+
         args.append(f"pose={SE3(self._T, check=False).strline()!r}")
         return f"{type(self).__name__}({', '.join(args)})"
 

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -327,7 +327,39 @@ class TestShape(unittest.TestCase):
         r = repr(s0)
 
         self.assertNotIn("\n", r)
-        self.assertEqual(r, "Cylinder(radius=1.0, length=2.0, pose='t = 0, 0, 0; rpy/zyx = 0°, 0°, 0°')")
+        self.assertEqual(
+            r,
+            "Cylinder(radius=1.0, length=2.0, color=(0.3, 0.3, 0.3), "
+            "pose='t = 0, 0, 0; rpy/zyx = 0°, 0°, 0°')",
+        )
+
+    def test_repr_shows_color_always_opacity_only_if_not_1(self):
+        opaque = gm.Cuboid([1, 1, 1], color=[1, 0, 0, 1])
+        self.assertIn("color=(1.0, 0.0, 0.0)", repr(opaque))
+        self.assertNotIn("opacity=", repr(opaque))
+
+        transparent = gm.Cuboid([1, 1, 1], color=[1, 0, 0, 0.5])
+        self.assertIn("color=(1.0, 0.0, 0.0)", repr(transparent))
+        self.assertIn("opacity=0.5", repr(transparent))
+
+    def test_repr_color_is_plain_float_not_numpy_scalar(self):
+        # self._color's elements can be numpy.float64 after color=[...]
+        # with a list/array input -- repr() must show a plain "1.0", not
+        # numpy's own "np.float64(1.0)".
+        s0 = gm.Sphere(1.0, color=[1, 0, 0, 1])
+        self.assertNotIn("np.float64", repr(s0))
+
+    def test_repr_handles_all_integer_3_tuple_color(self):
+        # color=(1, 0, 0) -- all-integer, 3-length (no alpha), a natural
+        # way to write opaque red. Must not be misread as 0-255 range
+        # (only normalises if any component > 1.0), must pad alpha to
+        # 1.0 (so opacity is correctly omitted), and must not leak
+        # numpy scalars into the repr.
+        s0 = gm.Cuboid([1, 1, 1], color=(1, 0, 0))
+        r = repr(s0)
+        self.assertIn("color=(1.0, 0.0, 0.0)", r)
+        self.assertNotIn("opacity=", r)
+        self.assertNotIn("np.float64", r)
 
     def test_str_is_single_line(self):
         s0 = gm.Cuboid([1, 1, 1], pose=sm.SE3.Trans(1, 2, 3))


### PR DESCRIPTION
## Summary
- `repr()` previously showed only the subclass-specific constructor params (`radius`, `scale`, ...) and `pose` -- never `color`/`opacity`, even though every shape has them.
- Added to the base `Shape.__repr__` (not per-subclass `_repr_params`, since these are common to every shape): `color` is always shown; `opacity` (`self.color[3]`) only when it's not `1.0` -- the fully-opaque default case doesn't need calling out.
- **Also fixes a real formatting bug this surfaced**: `self._color`'s elements can be `numpy.float64` (any `color=[...]`/`color=(...)` input goes through `array(value, dtype=float)`, and `tuple(ndarray)` yields numpy scalars, not plain floats) -- reprs as `np.float64(1.0)` instead of `1.0`. Harmless functionally (`float64` genuinely subclasses `float`, so `json.dumps()` was never actually broken by this, unlike the `int64` case fixed previously in the color setter), but ugly specifically in a repr. Coerced with `float(...)` inside `__repr__` itself, not touching the setter/storage.

## Test plan
- [x] Updated the one existing test asserting an exact `repr()` string
- [x] Added tests: color always shown / opacity only if `!= 1.0`, no `np.float64` leakage, and the all-integer-3-tuple case (`color=(1, 0, 0)`, no alpha -- confirmed it doesn't get misread as 0-255 range, correctly pads alpha to 1.0 so opacity is omitted, no numpy-scalar leakage)
- [x] Full suite passes (108 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)