### PR TITLE
feat: add CollisionShapeGroup, and a & operator for iscollided()

### DIFF
--- a/src/spatialgeometry/__init__.py
+++ b/src/spatialgeometry/__init__.py
@@ -6,6 +6,7 @@ from spatialgeometry.geom import (
     Arrow,
     Path,
     CollisionShape,
+    CollisionShapeGroup,
     Mesh,
     Cylinder,
     Cuboid,
@@ -21,6 +22,7 @@ __all__ = [
     # geom
     "Shape",
     "CollisionShape",
+    "CollisionShapeGroup",
     "Mesh",
     "Cylinder",
     "Cuboid",

--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import sys
 from abc import abstractmethod
+from collections import UserList
+from collections.abc import Iterable
 from typing import Any
 
 import numpy as np
@@ -69,12 +71,22 @@ class CollisionShape(Shape):
         """
         Return the minimum euclidean distance between self and shape.
 
-        :param shape: The shape to compare distance to
+        :param shape: The shape (or :class:`CollisionShapeGroup`) to
+            compare distance to
         :param inf_dist: Only return a result when distance < inf_dist
         :returns: (d, p1, p2) — distance and closest points in world frame,
             or (None, None, None) when the shapes are farther than inf_dist.
             d is negative when the shapes are penetrating.
         """
+        if isinstance(shape, CollisionShapeGroup):
+            # Delegate to the group's own iteration rather than duplicating
+            # it here -- swap p1/p2 back, since shape.closest_point(self,
+            # ...) returns them from the group's own point of view (p1 on
+            # the group, p2 on self), the opposite of this method's own
+            # "p1 on self, p2 on shape" contract.
+            d, p_other, p_self = shape.closest_point(self, inf_dist)
+            return d, p_self, p_other
+
         self._ensure_coal()
         shape._ensure_coal()
 
@@ -92,8 +104,11 @@ class CollisionShape(Shape):
         """
         Return True if self and shape have collided (distance ≤ 0).
 
-        :param shape: The shape to check against
+        :param shape: The shape (or :class:`CollisionShapeGroup`) to check
+            against
         """
+        if isinstance(shape, CollisionShapeGroup):
+            return shape.iscollided(self)
         d, _, _ = self.closest_point(shape)
         return d is not None and d <= 0
 
@@ -101,6 +116,209 @@ class CollisionShape(Shape):
         """Deprecated — use iscollided instead."""
         warn("collided is deprecated, use iscollided instead", FutureWarning)
         return self.iscollided(shape)
+
+    def __and__(self, other: object) -> bool:
+        """
+        ``a & b`` is ``a.iscollided(b)`` -- returns a bool, unlike e.g.
+        `shapely <https://shapely.readthedocs.io>`_'s ``&``/``intersection()``,
+        which returns a geometry. Works for shape-vs-shape, shape-vs-group,
+        and (via :class:`CollisionShapeGroup`'s own ``__and__``)
+        group-vs-shape and group-vs-group.
+
+        :param other: The shape (or :class:`CollisionShapeGroup`) to check
+            against
+        """
+        if not isinstance(other, CollisionShape):
+            return NotImplemented
+        return self.iscollided(other)
+
+
+class CollisionShapeGroup(CollisionShape, UserList):
+    """
+    An ordered, list-like collection of :class:`CollisionShape` (or nested
+    :class:`CollisionShapeGroup`) objects that itself behaves like a single
+    collision-checkable shape.
+
+    Unlike :class:`~spatialgeometry.SceneGroup`, which admits any
+    :class:`SceneNode`, a :class:`CollisionShapeGroup` only accepts
+    :class:`CollisionShape` or :class:`CollisionShapeGroup` instances --
+    adding anything else (a plain :class:`Shape` such as :class:`Axes`, for
+    instance) raises :exc:`TypeError`.
+
+    ``iscollided()``/``closest_point()`` work in every combination of
+    shape-vs-shape, shape-vs-group, group-vs-shape, and group-vs-group,
+    including arbitrarily nested groups -- a group checks each of its own
+    elements in turn (delegating to that element's own
+    ``iscollided()``/``closest_point()``, which handles the other side
+    being a group itself if needed) and aggregates: any element collided
+    means the group collided; the closest element's own ``(d, p1, p2)`` is
+    the group's.
+
+    A :class:`CollisionShapeGroup` has no single Coal collision geometry of
+    its own -- it is never itself passed to Coal, only iterated -- so
+    :meth:`to_dict` (there is no single dict that could describe a
+    collection) and :meth:`_init_coal` (there is no single geometry to
+    build) both raise if called directly. Nothing in normal use calls
+    either, since ``iscollided()``/``closest_point()`` never touch
+    ``self.co``.
+
+    Every element's ``scene_parent`` is kept pointing at the group, same as
+    :class:`SceneGroup` -- adding an element (via the constructor,
+    ``append``, ``extend``, ``insert``, or item assignment) sets it, and
+    removing one (``remove``, ``pop``, ``clear``, ``del``) clears it back
+    to ``None``.
+
+    .. runblock:: pycon
+
+        >>> from spatialgeometry import CollisionShapeGroup, Cuboid, Sphere
+        >>> from spatialmath import SE3
+        >>> group = CollisionShapeGroup()
+        >>> group.append(Cuboid([1, 1, 1]))
+        >>> group.append(Sphere(1, pose=SE3.Trans(3, 0, 0)))
+        >>> len(group)
+    """
+
+    def __init__(
+        self,
+        initlist: Iterable[CollisionShape] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            scene_children=(
+                [self._check_type(item) for item in initlist]
+                if initlist is not None
+                else None
+            ),
+            **kwargs,
+        )
+
+    @staticmethod
+    def _check_type(item: object) -> CollisionShape:
+        if not isinstance(item, (CollisionShape, CollisionShapeGroup)):
+            raise TypeError(
+                "CollisionShapeGroup only accepts CollisionShape or "
+                f"CollisionShapeGroup instances, got {type(item).__name__}"
+            )
+        return item
+
+    def __getitem__(self, i: int) -> CollisionShape:
+        return self._scene_children[i]
+
+    def __setitem__(self, i: int, item: CollisionShape) -> None:
+        if isinstance(i, slice):
+            raise NotImplementedError(
+                "Slice assignment is not supported for CollisionShapeGroup"
+            )
+        self._check_type(item)
+        old = self._scene_children[i]
+        self.remove(old)
+        self.insert(i, item)
+
+    def __delitem__(self, i: int | slice) -> None:
+        if isinstance(i, slice):
+            for item in list(self._scene_children[i]):
+                self.remove(item)
+        else:
+            self.remove(self._scene_children[i])
+
+    def append(self, item: CollisionShape) -> None:
+        """Add ``item`` to the end of the group and set its
+        ``scene_parent`` to this group."""
+        self._check_type(item)
+        item.scene_parent = self
+
+    def extend(self, other: Iterable[CollisionShape]) -> None:
+        """Add every element of ``other`` to the end of the group, setting
+        each one's ``scene_parent`` to this group."""
+        for item in other:
+            self.append(item)
+
+    def insert(self, i: int, item: CollisionShape) -> None:
+        """Insert ``item`` at position ``i`` and set its ``scene_parent``
+        to this group."""
+        self._check_type(item)
+        item.scene_parent = self
+        self._scene_children.insert(i, self._scene_children.pop())
+
+    def remove(self, item: CollisionShape) -> None:
+        """Remove ``item`` from the group and clear its ``scene_parent``."""
+        self._remove_scene_child(item)
+        item._scene_parent = None
+
+    def pop(self, i: int = -1) -> CollisionShape:
+        """Remove and return the element at position ``i`` (default: the
+        last one), clearing its ``scene_parent``."""
+        item = self._scene_children[i]
+        self.remove(item)
+        return item
+
+    def clear(self) -> None:
+        """Remove every element from the group, clearing each one's
+        ``scene_parent``."""
+        for item in list(self._scene_children):
+            self.remove(item)
+
+    @property
+    def data(self) -> list[CollisionShape]:
+        return self._scene_children
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.data!r})"
+
+    # --------------------------------------------------------------------- #
+    # Collision checking -- iterate this group's own elements, never touch
+    # self.co (there isn't one).
+    # --------------------------------------------------------------------- #
+
+    def _init_coal(self) -> None:
+        raise NotImplementedError(
+            "CollisionShapeGroup has no single Coal collision geometry -- "
+            "iscollided()/closest_point() iterate its elements instead, "
+            "this should never be called directly"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        raise NotImplementedError(
+            "CollisionShapeGroup cannot be represented as a single dict -- "
+            "iterate it and call to_dict() on each element instead"
+        )
+
+    def closest_point(
+        self, shape: CollisionShape, inf_dist: float = 1.0
+    ) -> tuple[float | None, np.ndarray | None, np.ndarray | None]:
+        """
+        Return the minimum euclidean distance between this group and
+        shape -- the closest ``(d, p1, p2)`` among this group's own
+        elements.
+
+        :param shape: The shape (or :class:`CollisionShapeGroup`) to
+            compare distance to
+        :param inf_dist: Only return a result when distance < inf_dist
+        :returns: (d, p1, p2) — distance and closest points in world frame,
+            or (None, None, None) when every element is farther than
+            inf_dist.
+        """
+        d = None
+        p1 = None
+        p2 = None
+
+        for element in self:
+            td, tp1, tp2 = element.closest_point(shape, inf_dist)
+            if td is not None and (d is None or td < d):
+                d = td
+                p1 = tp1
+                p2 = tp2
+
+        return d, p1, p2
+
+    def iscollided(self, shape: CollisionShape) -> bool:
+        """
+        Return True if any element of this group has collided with shape.
+
+        :param shape: The shape (or :class:`CollisionShapeGroup`) to check
+            against
+        """
+        return any(element.iscollided(shape) for element in self)
 
 
 class Mesh(CollisionShape):

--- a/src/spatialgeometry/geom/SceneGroup.py
+++ b/src/spatialgeometry/geom/SceneGroup.py
@@ -6,16 +6,98 @@
 from __future__ import annotations
 
 from collections import UserList
+from collections.abc import Iterable
 
 from spatialgeometry.geom.SceneNode import SceneNode
 
 
 class SceneGroup(SceneNode, UserList):
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+    """
+    An ordered, list-like collection of :class:`SceneNode` objects.
+
+    A :class:`SceneGroup` is itself a :class:`SceneNode` so its elements can be
+    collectively, parented or nested like any other node in the scene graph. This class
+    inherits from :class:`collections.UserList` so it behaves like a Python list, but it
+    is not a subclass of :class:`list` so it can be subclassed itself.
+
+    Every element's ``scene_parent`` is kept pointing at the group -- adding an
+    element (via the constructor, ``append``, ``extend``, ``insert``, or item
+    assignment) sets it, and removing one (``remove``, ``pop``, ``clear``,
+    ``del``) clears it back to ``None``. This is what makes moving the group
+    move its elements with it.
+
+    .. runblock:: pycon
+
+        >>> from spatialgeometry import SceneGroup, Cuboid, Sphere
+        >>> from spatialmath import SE3
+        >>> group = SceneGroup()
+        >>> print(len(group))
+        >>> group.append(Cuboid([1,2,3]))
+        >>> group.append(Sphere(1, pose=SE3.Trans(1,0,0)))
+        >>> print(len(group))
+    """
+
+    def __init__(
+        self, initlist: Iterable[SceneNode] | None = None, **kwargs
+    ) -> None:
+        super().__init__(
+            scene_children=list(initlist) if initlist is not None else None,
+            **kwargs,
+        )
 
     def __getitem__(self, i: int) -> SceneNode:
         return self._scene_children[i]
+
+    def __setitem__(self, i: int, item: SceneNode) -> None:
+        if isinstance(i, slice):
+            raise NotImplementedError(
+                "Slice assignment is not supported for SceneGroup"
+            )
+        old = self._scene_children[i]
+        self.remove(old)
+        self.insert(i, item)
+
+    def __delitem__(self, i: int | slice) -> None:
+        if isinstance(i, slice):
+            for item in list(self._scene_children[i]):
+                self.remove(item)
+        else:
+            self.remove(self._scene_children[i])
+
+    def append(self, item: SceneNode) -> None:
+        """Add ``item`` to the end of the group and set its ``scene_parent``
+        to this group."""
+        item.scene_parent = self
+
+    def extend(self, other: Iterable[SceneNode]) -> None:
+        """Add every element of ``other`` to the end of the group, setting
+        each one's ``scene_parent`` to this group."""
+        for item in other:
+            self.append(item)
+
+    def insert(self, i: int, item: SceneNode) -> None:
+        """Insert ``item`` at position ``i`` and set its ``scene_parent`` to
+        this group."""
+        item.scene_parent = self
+        self._scene_children.insert(i, self._scene_children.pop())
+
+    def remove(self, item: SceneNode) -> None:
+        """Remove ``item`` from the group and clear its ``scene_parent``."""
+        self._remove_scene_child(item)
+        item._scene_parent = None
+
+    def pop(self, i: int = -1) -> SceneNode:
+        """Remove and return the element at position ``i`` (default: the
+        last one), clearing its ``scene_parent``."""
+        item = self._scene_children[i]
+        self.remove(item)
+        return item
+
+    def clear(self) -> None:
+        """Remove every element from the group, clearing each one's
+        ``scene_parent``."""
+        for item in list(self._scene_children):
+            self.remove(item)
 
     @property
     def data(self) -> list[SceneNode]:

--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -223,6 +223,17 @@ class SceneNode:
         # Update c
         self.__update_c()
 
+    def _remove_scene_child(self, child: SceneNode) -> None:
+        """
+        Removes a child from this object, does NOT clear the
+        child's own scene_parent reference
+
+        """
+        self.scene_children.remove(child)
+
+        # Update c
+        self.__update_c()
+
     # --------------------------------------------------------------------- #
 
     @property

--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -165,14 +165,11 @@ class SceneNode:
         the parents child
 
         """
-        # Set our parent
-        self._scene_parent = parent
+        # Set our parent (also validates this won't create a cycle)
+        self._update_scene_parent(parent)
 
         # Update our parents children
         parent._update_scene_children(self)
-
-        # Update c
-        self.__update_c()
 
     def _update_scene_parent(self, parent: SceneNode) -> None:
         """
@@ -180,6 +177,26 @@ class SceneNode:
         the parents child
 
         """
+        # A node can't become its own ancestor -- walk the new parent's own
+        # chain of parents; if self shows up (or parent is self), this
+        # reparenting would create a cycle. Nothing downstream checks for
+        # this: _propogate_scene_tree()'s root-finding walk (SceneNode.py,
+        # also mirrored in scene.py and the compiled scene_nb.cpp) has no
+        # cycle detection of its own -- a parent-chain cycle makes it spin
+        # forever (an infinite loop, not a catchable exception), and
+        # Swift's env.step() calls it every step. O(depth) per call here;
+        # fine for how small these graphs actually get, see tech-debt
+        # issue for a cheaper approach if that ever stops being true.
+        ancestor = parent
+        while ancestor is not None:
+            if ancestor is self:
+                raise ValueError(
+                    f"Cannot set {self!r}'s scene_parent to {parent!r} -- "
+                    f"{parent!r} is already a descendant of {self!r}, this "
+                    "would create a cycle in the scene graph"
+                )
+            ancestor = ancestor.scene_parent
+
         self._scene_parent = parent
 
         # Update c

--- a/src/spatialgeometry/geom/__init__.py
+++ b/src/spatialgeometry/geom/__init__.py
@@ -3,6 +3,7 @@ from spatialgeometry.geom.SceneGroup import SceneGroup
 from spatialgeometry.geom.Shape import Shape, Axes, Arrow, Path
 from spatialgeometry.geom.CollisionShape import (
     CollisionShape,
+    CollisionShapeGroup,
     Mesh,
     Cylinder,
     Cuboid,
@@ -14,6 +15,7 @@ from spatialgeometry.geom.CollisionShape import (
 __all__ = [
     "Shape",
     "CollisionShape",
+    "CollisionShapeGroup",
     "Mesh",
     "Cylinder",
     "Cuboid",

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -343,6 +343,71 @@ class TestShape(unittest.TestCase):
         self.assertEqual(repr(group), f"SceneGroup([{gm.Sphere(1.0)!r}])")
         self.assertTrue(str(group).startswith("SceneGroup at "))
 
+    def test_scene_group_constructor_accepts_initial_elements(self):
+        cube = gm.Cuboid([1, 1, 1])
+        sphere = gm.Sphere(1.0)
+        group = gm.SceneGroup([cube, sphere])
+
+        self.assertEqual(len(group), 2)
+        self.assertIs(cube.scene_parent, group)
+        self.assertIs(sphere.scene_parent, group)
+
+    def test_scene_group_mutators_set_and_clear_scene_parent(self):
+        group = gm.SceneGroup()
+
+        box = gm.Cuboid([1, 1, 1])
+        group.append(box)
+        self.assertIs(box.scene_parent, group)
+
+        extra = gm.Sphere(0.5)
+        group.extend([extra])
+        self.assertIs(extra.scene_parent, group)
+
+        mid = gm.Sphere(0.3)
+        group.insert(1, mid)
+        self.assertEqual(list(group), [box, mid, extra])
+        self.assertIs(mid.scene_parent, group)
+
+        group.remove(box)
+        self.assertIsNone(box.scene_parent)
+        self.assertEqual(len(group), 2)
+
+        popped = group.pop()
+        self.assertIs(popped, extra)
+        self.assertIsNone(popped.scene_parent)
+
+        group.clear()
+        self.assertEqual(len(group), 0)
+
+    def test_scene_group_setitem_and_delitem_set_and_clear_scene_parent(self):
+        group = gm.SceneGroup([gm.Cuboid([1, 1, 1]), gm.Sphere(1.0)])
+        old_item = group[0]
+        new_item = gm.Sphere(2.0)
+
+        group[0] = new_item
+        self.assertIs(group[0], new_item)
+        self.assertIs(new_item.scene_parent, group)
+        self.assertIsNone(old_item.scene_parent)
+
+        del group[0]
+        self.assertEqual(len(group), 1)
+
+    def test_scene_group_scene_parent_does_not_flatten_its_elements(self):
+        # Setting a SceneGroup's own scene_parent should only affect the
+        # group itself -- its own elements must stay its elements, not get
+        # reparented to the new parent too.
+        parent = gm.Cuboid([1, 1, 1])
+        group = gm.SceneGroup([gm.Cuboid([1, 1, 1])])
+
+        group.scene_parent = parent
+        self.assertIs(group.scene_parent, parent)
+        self.assertEqual(len(group), 1)
+
+        parent.T = sm.SE3(5, 0, 0)
+        parent._propogate_scene_tree()
+        nt.assert_almost_equal(group._wT[:3, 3], [5, 0, 0])
+        nt.assert_almost_equal(group[0]._wT[:3, 3], [5, 0, 0])
+
     def test_Path_defaults(self):
         # points is accepted/stored as 3xN (this ecosystem's own point-set
         # convention), but the wire format transposes to a flat N x 3 list

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -205,6 +205,41 @@ class TestShape(unittest.TestCase):
         expected = sm.SE3.Trans(1, 0, 0).A @ sm.SE3.Trans(0, 2, 0).A
         nt.assert_almost_equal(child._wT, expected)
 
+    def test_scene_parent_rejects_self_parenting(self):
+        a = gm.Cuboid([1, 1, 1])
+        with self.assertRaises(ValueError):
+            a.scene_parent = a
+
+    def test_scene_parent_rejects_two_node_cycle(self):
+        a = gm.Cuboid([1, 1, 1])
+        b = gm.Cuboid([1, 1, 1])
+        b.scene_parent = a
+        with self.assertRaises(ValueError):
+            a.scene_parent = b
+
+    def test_scene_parent_rejects_longer_cycle(self):
+        x = gm.Cuboid([1, 1, 1])
+        y = gm.Cuboid([1, 1, 1])
+        z = gm.Cuboid([1, 1, 1])
+        y.scene_parent = x
+        z.scene_parent = y
+        with self.assertRaises(ValueError):
+            x.scene_parent = z
+
+    def test_attach_to_rejects_cycle(self):
+        # attach_to() goes through scene_parent -- same protection applies.
+        m = gm.Cuboid([1, 1, 1])
+        n = gm.Cuboid([1, 1, 1])
+        n.attach_to(m)
+        with self.assertRaises(ValueError):
+            m.attach_to(n)
+
+    def test_valid_reparenting_still_works(self):
+        p = gm.Cuboid([1, 1, 1])
+        q = gm.Cuboid([1, 1, 1])
+        q.scene_parent = p
+        self.assertIs(q.scene_parent, p)
+
     def test_mesh_collision_false(self):
         s0 = gm.Mesh("test.stl", collision=False)
         with self.assertRaises(ValueError):

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -411,6 +411,73 @@ class TestClosestChain:
         assert (d, p1, p2) == (None, None, None)
 
 
+# ── SceneGroup collision (first-principles, SG only) ────────────────────────
+#
+# Not "do pose values propagate" (see TestShape's scene-graph tests) but "does
+# Coal-backed iscollided()/closest_point() give correct, currently-live
+# results for elements inside a SceneGroup built via the normal list
+# interface (append()), not just via scene_children= at construction time."
+# This is exactly the code path that had a scene_parent wiring bug before
+# this fix -- append() only mutated the raw list, never wired the element's
+# own scene_parent or refreshed the group's cached scene-graph children, so a
+# moved/reparented group's elements kept reporting stale collision geometry.
+
+@skip_no_collision_checking
+class TestSceneGroupCollision:
+    def test_append_built_group_tracks_reparenting(self):
+        # Parent established BEFORE the append, not after -- appending to an
+        # already-parented group is the scenario that actually exposes a
+        # stale/never-refreshed scene-graph cache; appending before parenting
+        # would incidentally get swept up by the group's own
+        # scene_parent-setter refresh regardless of whether append() itself
+        # is wired correctly, silently defeating this as a regression test.
+        anchor = cuboid_at(0.1, 0.1, 0.1)
+        group = gm.SceneGroup()
+        group.scene_parent = anchor
+        col = Cuboid([1, 1, 1])
+        group.append(col)
+
+        probe = cuboid_at(1, 1, 1, x=13)
+
+        # col at world x=0 (identity offset through group -> anchor): faces
+        # at 0.5 and 12.5 -> gap 12.0
+        d0, _, _ = col.closest_point(probe, BIG)
+        assert d0 == pytest.approx(12.0, abs=1e-6)
+
+        anchor.T = SE3(10, 0, 0)
+        anchor._propogate_scene_tree()
+
+        # col now at world x=10: faces at 10.5 and 12.5 -> gap 2.0. If the
+        # group's append() hadn't wired col into the propagated scene graph,
+        # col._wT would still read as it did before the move and this would
+        # incorrectly still be 12.0.
+        d1, _, _ = col.closest_point(probe, BIG)
+        assert d1 == pytest.approx(2.0, abs=1e-6)
+
+    def test_multiple_appended_elements_all_tracked_independently(self):
+        anchor = cuboid_at(0.1, 0.1, 0.1)
+        group = gm.SceneGroup()
+        group.scene_parent = anchor
+        c1 = Cuboid([1, 1, 1])              # local offset 0
+        c2 = cuboid_at(1, 1, 1, x=5)         # local offset +5
+        group.append(c1)
+        group.append(c2)
+
+        anchor.T = SE3(20, 0, 0)
+        anchor._propogate_scene_tree()
+
+        # c1 -> world x=20, c2 -> world x=25 (its own local +5 composed on
+        # top of anchor's move)
+        assert c1.iscollided(cuboid_at(1, 1, 1, x=20))
+        assert c2.iscollided(cuboid_at(1, 1, 1, x=25))
+
+        # cross-check both directions, so a bug that only wires the *last*
+        # (or *first*) appended element can't hide behind a single passing
+        # assertion above
+        assert not c1.iscollided(cuboid_at(1, 1, 1, x=25))
+        assert not c2.iscollided(cuboid_at(1, 1, 1, x=20))
+
+
 # ── to_dict ───────────────────────────────────────────────────────────────────
 
 class TestToDict:

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -27,7 +27,14 @@ import spatialgeometry.geom as gm
 import spatialgeometry.geom.CollisionShape   # ensure loaded
 _mod = sys.modules["spatialgeometry.geom.CollisionShape"]
 
-from spatialgeometry.geom.CollisionShape import Sphere, Cuboid, Cylinder, Box
+from spatialgeometry.geom.CollisionShape import (
+    Sphere,
+    Cuboid,
+    Cylinder,
+    Box,
+    CollisionShapeGroup,
+)
+from spatialgeometry.geom.Shape import Axes
 
 from tests import skip_no_collision_checking
 
@@ -476,6 +483,106 @@ class TestSceneGroupCollision:
         # assertion above
         assert not c1.iscollided(cuboid_at(1, 1, 1, x=25))
         assert not c2.iscollided(cuboid_at(1, 1, 1, x=20))
+
+
+# ── CollisionShapeGroup ──────────────────────────────────────────────────────
+
+@skip_no_collision_checking
+class TestCollisionShapeGroup:
+    def test_rejects_non_collision_shape_types(self):
+        with pytest.raises(TypeError):
+            CollisionShapeGroup([Axes(1.0)])
+
+        group = CollisionShapeGroup()
+        with pytest.raises(TypeError):
+            group.append("not a shape")
+        with pytest.raises(TypeError):
+            group.append(Axes(1.0))
+
+    def test_scene_parent_wiring_matches_scenegroup(self):
+        # Same regression shape as TestSceneGroupCollision above: parent
+        # established before append, so a wiring bug in append() would
+        # leave col's world pose stale after the anchor moves.
+        anchor = cuboid_at(0.1, 0.1, 0.1)
+        col = Cuboid([1, 1, 1])
+        group = CollisionShapeGroup()
+        group.scene_parent = anchor
+        group.append(col)
+
+        assert col.scene_parent is group
+
+        anchor.T = SE3(10, 0, 0)
+        anchor._propogate_scene_tree()
+
+        probe = cuboid_at(1, 1, 1, x=13)
+        d, _, _ = col.closest_point(probe, BIG)
+        assert d == pytest.approx(2.0, abs=1e-6)
+
+        group.remove(col)
+        assert col.scene_parent is None
+
+    def test_shape_x_shape_is_unaffected(self):
+        # Baseline: adding group-awareness to CollisionShape.iscollided()/
+        # closest_point() must not change plain shape-vs-shape behaviour.
+        assert not cuboid_at(1, 1, 1).iscollided(cuboid_at(1, 1, 1, x=5))
+        d, _, _ = cuboid_at(1, 1, 1).closest_point(cuboid_at(1, 1, 1, x=5), BIG)
+        assert d == pytest.approx(4.0, abs=1e-6)
+
+    def test_group_x_shape_and_shape_x_group_agree(self):
+        group = CollisionShapeGroup(
+            [cuboid_at(1, 1, 1), sphere_at(1.0, x=10)]
+        )
+        near = cuboid_at(1, 1, 1, x=0.5)   # overlaps group[0]
+        far = cuboid_at(1, 1, 1, x=50)
+
+        assert group.iscollided(near)
+        assert near.iscollided(group)      # shape-side delegates to group
+        assert not group.iscollided(far)
+        assert not far.iscollided(group)
+
+    def test_closest_point_p1_p2_swap_correctly_between_directions(self):
+        group = CollisionShapeGroup([cuboid_at(1, 1, 1)])
+        other = cuboid_at(1, 1, 1, x=5)
+
+        d_a, p1_a, p2_a = other.closest_point(group, BIG)
+        d_b, p1_b, p2_b = group.closest_point(other, BIG)
+
+        # Same distance either way, but p1/p2 (on self, on other) must be
+        # swapped between the two calls, not identical.
+        assert d_a == pytest.approx(d_b, abs=1e-6)
+        np.testing.assert_allclose(p1_a, p2_b)
+        np.testing.assert_allclose(p2_a, p1_b)
+
+    def test_group_x_group_and_nested_groups(self):
+        group_a = CollisionShapeGroup([cuboid_at(1, 1, 1)])
+        group_b = CollisionShapeGroup([cuboid_at(1, 1, 1, x=0.5)])
+        assert group_a.iscollided(group_b)
+
+        far_group = CollisionShapeGroup([cuboid_at(1, 1, 1, x=50)])
+        assert not group_a.iscollided(far_group)
+
+        nested = CollisionShapeGroup([group_b])
+        assert group_a.iscollided(nested)
+
+    def test_and_operator_both_directions(self):
+        group = CollisionShapeGroup([cuboid_at(1, 1, 1)])
+        near = cuboid_at(1, 1, 1, x=0.5)
+        far = cuboid_at(1, 1, 1, x=50)
+
+        assert (group & near) is True
+        assert (near & group) is True
+        assert (group & far) is False
+
+    def test_and_operator_unrelated_type_raises_type_error(self):
+        with pytest.raises(TypeError):
+            cuboid_at(1, 1, 1) & 5
+
+    def test_to_dict_and_init_coal_raise(self):
+        group = CollisionShapeGroup([cuboid_at(1, 1, 1)])
+        with pytest.raises(NotImplementedError):
+            group.to_dict()
+        with pytest.raises(NotImplementedError):
+            group._init_coal()
 
 
 # ── to_dict ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
**Stacks on #21** (SceneGroup list wiring -- the pattern this replicates) **and #27** (scene_parent cycle detection). Same GitHub limitation as #29/#31: base branch can't live only on a fork, so this is based against `main` and the diff includes both of those PRs' changes -- the only new commit is bcfa91f. Please review #21 and #27 first.

- `CollisionShapeGroup(CollisionShape, UserList)` -- an ordered, list-like collection that only accepts `CollisionShape` or `CollisionShapeGroup` instances (constructor/`append`/`extend`/`insert`/`__setitem__` all type-check, raising `TypeError` otherwise), and itself behaves like a single collision-checkable shape.
- **Not a mixin shared with `SceneGroup`** -- deliberately replicated the list-mutator wiring directly rather than extracting a shared base. Some duplication, but avoids a new abstraction shared across two otherwise-unrelated hierarchies, and lets `CollisionShapeGroup` inherit `CollisionShape` directly so things like the new `&` operator apply uniformly to both plain shapes and groups without a second definition.
- `iscollided()`/`closest_point()` work in every combination -- shape x shape (unchanged), shape x group, group x shape, group x group, including arbitrarily nested groups. The "is the other side a group" branch lives in exactly one place (the base `CollisionShape` methods); `CollisionShapeGroup`'s own versions just iterate their own elements and delegate each check back through that same branch, so nesting at any depth falls out via mutual recursion, no special-casing per combination.
- No single Coal geometry of its own -- `to_dict()`/`_init_coal()` both raise if called directly (nothing in normal use calls either).
- `CollisionShape.__and__`: `a & b` is `a.iscollided(b)`. Returns `NotImplemented` (not a custom error) for a non-`CollisionShape` other, so Python's own protocol produces the `TypeError`. Docstring flags the semantic difference from `shapely`'s `&`/`intersection()` (returns a geometry there, a bool here). No `__rand__` needed -- both classes always define `__and__` directly, so whichever side Python evaluates first already succeeds.

**No RTB changes in this PR** -- this sets up the SG-side building block for eventually simplifying `Link.iscollided()`/`closest_point()`'s current manual iteration loop. See petercorke/robotics-toolbox-python#569 for that follow-up (not done here).

## Test plan
- [x] Full suite passes (125 tests, 9 new)
- [x] Covers: type-rejection (non-`CollisionShape` items), `scene_parent` wiring on `append`/`remove` (same regression shape as #21's own tests), shape-vs-shape baseline unaffected, group-vs-shape and shape-vs-group agree, `closest_point()`'s p1/p2 correctly swap between call directions, group-vs-group and nested groups, `&` both directions plus `TypeError` for an unrelated type, `to_dict()`/`_init_coal()` raise cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)