### PR TITLE
feat: add Shape.opacity property, deprecate set_alpha()

### DIFF
--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -259,8 +259,9 @@ class Shape(SceneNode, ABC):
     @property
     def color(self) -> tuple[float, float, float, float]:
         """
-        shape.color returns a four length tuple representing (red, green, blue, alpha)
-        where alpha represents transparency. Values returned are in the range [0-1].
+        shape.color returns a four length tuple representing (red, green, blue, opacity)
+        where opacity represents transparency. Values returned are in the range [0-1].
+        See :attr:`opacity` for a convenient way to get/set just this last channel.
         """
         return self._color
 
@@ -270,13 +271,13 @@ class Shape(SceneNode, ABC):
         """
         shape.color(new_color) sets the color of a shape.
 
-        The color format is (red, green, blue, alpha).
+        The color format is (red, green, blue, opacity).
 
         Color can be set with a three length list, tuple or array which
-        will only set the (r, g, b) values and alpha will be set to maximum.
+        will only set the (r, g, b) values and opacity will be set to maximum.
 
         Color can be set with a four length list, tuple or array which
-        will set the (r, g, b, a) values.
+        will set the (r, g, b, opacity) values.
 
         Note: the color is auto-normalising. If any value passed is greater than
         1.0 then all values will be normalised to the [0-1] range assuming the
@@ -325,10 +326,15 @@ class Shape(SceneNode, ABC):
     @property
     def opacity(self) -> float:
         """
-        The alpha/opacity channel of :attr:`color`, in [0-1] -- 1.0 is
-        fully opaque, 0.0 fully transparent. A convenience for touching
-        just this channel without needing to know or re-specify the
-        current (r, g, b).
+        The last channel of :attr:`color`, in [0-1] -- 1.0 is fully
+        opaque, 0.0 fully transparent. A convenience for touching just
+        this channel without needing to know or re-specify the current
+        (r, g, b).
+
+        .. note::
+            "Opacity" here is the same quantity commonly called "alpha"
+            in computer graphics (as in RGBA) -- this package uses
+            "opacity" consistently as the public name for it.
 
         This is a read/write property.
 

--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -322,16 +322,32 @@ class Shape(SceneNode, ABC):
 
         self._color = value
 
+    @property
+    def opacity(self) -> float:
+        """
+        The alpha/opacity channel of :attr:`color`, in [0-1] -- 1.0 is
+        fully opaque, 0.0 fully transparent. A convenience for touching
+        just this channel without needing to know or re-specify the
+        current (r, g, b).
+
+        This is a read/write property.
+
+        :rtype: float
+        """
+        return self._color[3]
+
+    @opacity.setter
+    @update
+    def opacity(self, value: float) -> None:
+        if value > 1.0:
+            value /= 255
+
+        self._color = tuple(concatenate([self._color[:3], [value]]))
+
     def set_alpha(self, alpha: float | int) -> None:
-        """
-        Convenience method to set the opacity/alpha value of the robots color.
-        """
-
-        if alpha > 1.0:
-            alpha /= 255
-
-        new_color = concatenate([self._color[:3], [alpha]])
-        self._color = tuple(new_color)
+        """Deprecated -- use the ``opacity`` property instead."""
+        warn("set_alpha is deprecated, use the opacity property instead", FutureWarning)
+        self.opacity = alpha
 
     # --------------------------------------------------------------------- #
     # Bounding box

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -66,6 +66,26 @@ class TestShape(unittest.TestCase):
         self.assertIsInstance(shape.color[3], float)
         json.dumps(shape.to_dict())  # must not raise TypeError
 
+    def test_opacity_property(self):
+        shape = gm.Cuboid([1, 1, 1], color=[0.1, 0.2, 0.3, 0.5])
+        self.assertEqual(shape.opacity, 0.5)
+
+        shape.opacity = 0.25
+        self.assertEqual(shape.opacity, 0.25)
+        # rgb untouched by an opacity-only set
+        self.assertEqual(shape.color[0], 0.1)
+        self.assertEqual(shape.color[1], 0.2)
+        self.assertEqual(shape.color[2], 0.3)
+
+        shape.opacity = 100  # >1 -- auto-normalised as 0-255 input
+        self.assertAlmostEqual(shape.opacity, 100 / 255)
+
+    def test_set_alpha_warns_and_matches_opacity(self):
+        shape = gm.Cuboid([1, 1, 1], color=[0.1, 0.2, 0.3, 1.0])
+        with self.assertWarns(FutureWarning):
+            shape.set_alpha(0.4)
+        self.assertEqual(shape.opacity, 0.4)
+
     def test_to_dict(self):
         s1 = gm.Cylinder(1, 1)
 


### PR DESCRIPTION
## Summary
- `set_alpha()` was the only `set_xxx()`-style method anywhere in the package -- every other mutable attribute (`color`, `scale`, `T`/pose, `radius`, `length`, ...) is a plain `@property`/`@x.setter` pair. It dates to commit `a806759` (2021-07-26, the same commit that introduced `color` itself), and exists because there was no standalone way to touch just the alpha channel without knowing/re-specifying the current `(r, g, b)`.
- Added a proper `opacity` property filling that actual gap (get/set, same `>1.0` means `0-255` auto-normalisation `set_alpha` already had).
- Turned `set_alpha()` into a thin deprecated wrapper -- same `warn(..., FutureWarning)` pattern already used here for `Box`->`Cuboid` and `collided()`->`iscollided()`.

## Test plan
- [x] `pytest tests/` -- 161 passed (159 existing + 2 new: `opacity` get/set including that an opacity-only set leaves rgb untouched and the `>1.0` normalisation, and that `set_alpha()` warns and produces the same result as the `opacity` setter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)