### PR TITLE
feat: check Mesh filename exists at construction, not just on lazy load

### DIFF
--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from abc import abstractmethod
 from collections import UserList
@@ -356,7 +357,12 @@ class Mesh(CollisionShape):
     """
     A mesh object described by an STL, OBJ, or DAE file.
 
-    :param filename: Absolute path to the mesh file.
+    :param filename: Absolute path to the mesh file. Checked for existence
+        at construction (raises :exc:`FileNotFoundError` if missing) --
+        this only confirms the path exists, not that it's a well-formed or
+        readable mesh file, which is still discovered lazily, the first
+        time the file is actually loaded (see :meth:`_init_coal` and
+        :meth:`_local_corners`).
     :param scale: Scale factor(s) along XYZ axes (default [1, 1, 1]). A
         single number applies the same scale to all three axes.
     :param color: Flat colour override, applied to every face/vertex. If
@@ -381,6 +387,9 @@ class Mesh(CollisionShape):
         y_up: bool = False,
         **kwargs,
     ) -> None:
+        if filename is not None and not os.path.isfile(filename):
+            raise FileNotFoundError(f"Mesh file not found: {filename!r}")
+
         super().__init__(stype="mesh", color=color, **kwargs)
         self.filename = filename
         self.scale = scale

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -6,6 +6,8 @@
 import numpy.testing as nt
 import numpy as np
 import unittest
+import tempfile
+import os
 import spatialmath as sm
 import spatialgeometry as gm
 
@@ -13,6 +15,19 @@ from tests import skip_no_collision_checking
 
 
 class TestShape(unittest.TestCase):
+    # A path that exists on disk but isn't a real mesh file -- Mesh() checks
+    # existence at construction, but none of these tests actually load the
+    # file's content, so a shared empty placeholder is enough for all of them.
+    @classmethod
+    def setUpClass(cls):
+        cls._mesh_tmpdir = tempfile.TemporaryDirectory()
+        cls.mesh_path = os.path.join(cls._mesh_tmpdir.name, "placeholder.stl")
+        open(cls.mesh_path, "w").close()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._mesh_tmpdir.cleanup()
+
     def test_init(self):
         gm.Cuboid([1, 1, 1], base=sm.SE3(0, 0, 0))
         gm.Cylinder(1, 1, base=sm.SE3(2, 0, 0))
@@ -241,26 +256,40 @@ class TestShape(unittest.TestCase):
         self.assertIs(q.scene_parent, p)
 
     def test_mesh_collision_false(self):
-        s0 = gm.Mesh("test.stl", collision=False)
+        s0 = gm.Mesh(self.mesh_path, collision=False)
         with self.assertRaises(ValueError):
             s0._init_coal()
 
+    def test_mesh_missing_file_raises_at_construction(self):
+        # Regression test: a bad filename used to go unnoticed until the
+        # lazy load inside _init_coal()/_local_corners() -- e.g. deep
+        # inside some later bounds() or iscollided() call, far from the
+        # actual mistake. Now checked (existence only, not validity as a
+        # mesh) at construction, so it fails immediately and loudly.
+        bad_path = os.path.join(self._mesh_tmpdir.name, "does_not_exist.stl")
+        with self.assertRaises(FileNotFoundError):
+            gm.Mesh(bad_path)
+
+    def test_mesh_no_filename_is_still_allowed(self):
+        # filename=None is not checked -- there's nothing to check.
+        gm.Mesh(None)
+
     def test_mesh_scalar_scale(self):
-        s0 = gm.Mesh("test.stl", scale=2.0)
+        s0 = gm.Mesh(self.mesh_path, scale=2.0)
         nt.assert_almost_equal(s0.scale, [2.0, 2.0, 2.0])
 
     def test_mesh_list_scale_still_works(self):
-        s0 = gm.Mesh("test.stl", scale=[1.0, 2.0, 3.0])
+        s0 = gm.Mesh(self.mesh_path, scale=[1.0, 2.0, 3.0])
         nt.assert_almost_equal(s0.scale, [1.0, 2.0, 3.0])
 
     def test_mesh2(self):
-        s0 = gm.Mesh("test.stl")
+        s0 = gm.Mesh(self.mesh_path)
 
         ans = {
             "stype": "mesh",
             "scale": [1.0, 1.0, 1.0],
             "y_up": False,
-            "filename": "test.stl",
+            "filename": self.mesh_path,
             "t": [0.0, 0.0, 0.0],
             "q": [0.0, 0.0, 0.0, 1],
             "v": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
@@ -273,15 +302,15 @@ class TestShape(unittest.TestCase):
 
     def test_mesh_use_vertex_colors(self):
         # No explicit color -- defer to whatever's baked into the file.
-        s0 = gm.Mesh("test.stl")
+        s0 = gm.Mesh(self.mesh_path)
         self.assertTrue(s0.to_dict()["use_vertex_colors"])
 
         # Explicit color at construction -- always overrides.
-        s1 = gm.Mesh("test.stl", color=[1.0, 0.0, 0.0, 1.0])
+        s1 = gm.Mesh(self.mesh_path, color=[1.0, 0.0, 0.0, 1.0])
         self.assertFalse(s1.to_dict()["use_vertex_colors"])
 
         # Explicit color set after construction -- also overrides.
-        s2 = gm.Mesh("test.stl")
+        s2 = gm.Mesh(self.mesh_path)
         s2.color = [0.0, 1.0, 0.0, 1.0]
         self.assertFalse(s2.to_dict()["use_vertex_colors"])
 

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -63,6 +63,15 @@ def ellipsoid_at(radii, x=0.0, y=0.0, z=0.0) -> Ellipsoid:
     return Ellipsoid(radii, pose=SE3(x, y, z))
 
 
+def _placeholder_mesh_file(tmp_path, name: str = "placeholder.stl") -> str:
+    """A path that exists on disk but isn't a real mesh file -- Mesh() checks
+    existence at construction, but these tests never actually load its
+    content, so an empty file satisfies the check."""
+    path = tmp_path / name
+    path.touch()
+    return str(path)
+
+
 BIG = 1e6   # inf_dist large enough to always get a result
 
 
@@ -712,14 +721,17 @@ class TestToDict:
         d = gm.Ellipsoid([0.3, 0.2, 0.15]).to_dict()
         assert d["radii"] == [0.3, 0.2, 0.15]
 
-    def test_mesh_stype(self):
-        assert gm.Mesh("robot.stl").to_dict()["stype"] == "mesh"
+    def test_mesh_stype(self, tmp_path):
+        path = _placeholder_mesh_file(tmp_path)
+        assert gm.Mesh(path).to_dict()["stype"] == "mesh"
 
-    def test_mesh_filename(self):
-        assert gm.Mesh("robot.stl").to_dict()["filename"] == "robot.stl"
+    def test_mesh_filename(self, tmp_path):
+        path = _placeholder_mesh_file(tmp_path)
+        assert gm.Mesh(path).to_dict()["filename"] == path
 
-    def test_mesh_scale(self):
-        assert gm.Mesh("robot.stl", scale=[2, 2, 2]).to_dict()["scale"] == [2.0, 2.0, 2.0]
+    def test_mesh_scale(self, tmp_path):
+        path = _placeholder_mesh_file(tmp_path)
+        assert gm.Mesh(path, scale=[2, 2, 2]).to_dict()["scale"] == [2.0, 2.0, 2.0]
 
 
 # ── _init_coal collision=False direct call ────────────────────────────────────
@@ -728,8 +740,9 @@ class TestToDict:
 class TestInitCoalDirect:
     """Call _init_coal() directly, matching the pattern in the original suite."""
 
-    def test_mesh_collision_false(self):
-        s = gm.Mesh("test.stl", collision=False)
+    def test_mesh_collision_false(self, tmp_path):
+        path = _placeholder_mesh_file(tmp_path)
+        s = gm.Mesh(path, collision=False)
         _mod._require_coal()   # ensure coal loaded so _init_coal can proceed
         with pytest.raises(ValueError, match="collision=False"):
             s._init_coal()


### PR DESCRIPTION
## Summary
- A bad `filename` went unnoticed until whichever load path happened to run first -- `_init_coal()` (via `closest_point()`/`iscollided()`) or `_local_corners()` (via `corners()`/`bounds()`/`extents()`) -- which could be arbitrarily far downstream of the actual typo (e.g. only surfacing once two robot links get close enough to need a real distance check).
- Now checked (`os.path.isfile()`, stdlib only) at construction, raising `FileNotFoundError` immediately.
- Deliberately existence-only, not a real load -- keeps the existing principle that constructing a `Mesh` never requires `trimesh` to be installed (a mesh destined only for Swift display never needs the `mesh`/`collision` extras). Docstring calls this out explicitly.

## Test plan
- [x] `pytest tests/` -- 161 passed (159 existing + 2 new: a bad path raises `FileNotFoundError` at construction rather than lazily, and `filename=None` remains allowed). Existing tests using placeholder filenames like `"test.stl"`/`"robot.stl"` (never dereferenced -- they test `to_dict()`/`scale`/etc., not actual mesh content) now use a real placeholder file via `tmp_path`/`tempfile`, since construction now checks existence regardless of whether a test ever loads the content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)