### PR TITLE
fix: color error message names matplotlib and points to the color list

### DIFF
--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -290,7 +290,11 @@ class Shape(SceneNode, ABC):
                 try:
                     value = mpc.to_rgba(value)
                 except ValueError:
-                    print(f"{value} is an invalid color name, using default color")
+                    print(
+                        f"{value!r} is not a valid matplotlib color name -- see "
+                        "https://matplotlib.org/stable/gallery/color/named_colors.html "
+                        "for the full list. Using default color."
+                    )
                     value = default_color
             else:  # pragma nocover
                 value = default_color

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -178,6 +178,21 @@ class TestShape(unittest.TestCase):
         s0 = gm.Sphere(1, color="sdgfsg")
         self.assertEqual(s0.color, (0.95, 0.5, 0.25, 1.0))
 
+    def test_color_invalid_name_message_mentions_matplotlib(self):
+        # Regression test: the printed message used to just say "invalid
+        # color name" with no indication of where valid names actually
+        # come from (matplotlib), or where to look them up.
+        import io
+        import contextlib
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            gm.Sphere(1, color="sdgfsg")
+
+        printed = buf.getvalue()
+        self.assertIn("matplotlib", printed)
+        self.assertIn("named_colors", printed)
+
     def test_color3(self):
         s0 = gm.Sphere(1, color=[255, 255, 255])
         self.assertEqual(s0.color, (1.0, 1.0, 1.0, 1.0))


### PR DESCRIPTION
## Summary
- An invalid color name (e.g. `"darkbrown"`/`"lightbrown"`, found in `docs/source/intro.rst`'s household-scene example -- neither is an actual matplotlib name, fixed there separately to `saddlebrown`/`peru`) just printed `"X is an invalid color name, using default color"` with no indication of where valid names actually come from, or where to look them up.
- Now names matplotlib explicitly and links its named-colors reference page. Behaviour otherwise unchanged -- still prints a warning and falls back to the default color rather than raising, this is just about the message being informative.

## Test plan
- [x] `pytest tests/` -- 160 passed (159 existing + 1 new: the printed message mentions both "matplotlib" and "named_colors").

🤖 Generated with [Claude Code](https://claude.com/claude-code)