### PR TITLE
fix: give SceneNode.__init__ a pose= kwarg, not just Shape

### DIFF
--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -15,10 +15,22 @@ from copy import deepcopy
 class SceneNode:
     def __init__(
         self,
-        T: ndarray = eye(4),
+        pose: ndarray | SE3 = eye(4),
         scene_parent: SceneNode | None = None,
         scene_children: list[SceneNode] | None = None,
     ) -> None:
+        """
+        :param pose: Local reference frame of this node relative to its
+            parent in the scene graph (or the world frame if it has no
+            parent), defaults to the identity transform.
+        :param scene_parent: Parent node of this node in the scene graph.
+        :param scene_children: Child nodes of this node in the scene graph.
+        """
+        if isinstance(pose, SE3):
+            T = pose.A
+        else:
+            T = pose
+
         # These three are static attributes which can never be changed
         # If these are directly accessed and re-written, segmentation faults
         # will follow very soon after
@@ -136,7 +148,7 @@ class SceneNode:
 
     def __deepcopy__(self, memo):
         result = SceneNode(
-            T=self._T,
+            pose=self._T,
         )
 
         result._scene_children = self.scene_children.copy()

--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -138,7 +138,7 @@ class Shape(SceneNode, ABC):
             self.color = color
 
         # Initialise the scene node
-        super().__init__(T=T, **kwargs)
+        super().__init__(pose=T, **kwargs)
 
         self.stype = stype
         self.v = zeros(6)

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -454,6 +454,14 @@ class TestShape(unittest.TestCase):
         self.assertEqual(repr(group), f"SceneGroup([{gm.Sphere(1.0)!r}])")
         self.assertTrue(str(group).startswith("SceneGroup at "))
 
+    def test_scene_group_constructor_accepts_pose(self):
+        T = sm.SE3.Trans(1, 2, 3)
+        group = gm.SceneGroup(pose=T)
+        nt.assert_almost_equal(group._T, T.A)
+
+        group2 = gm.SceneGroup(pose=T.A)
+        nt.assert_almost_equal(group2._T, T.A)
+
     def test_scene_group_constructor_accepts_initial_elements(self):
         cube = gm.Cuboid([1, 1, 1])
         sphere = gm.Sphere(1.0)


### PR DESCRIPTION
## Summary

`SceneNode` is the true base class for everything in the scene graph, but
the friendly `pose: ndarray | SE3` constructor kwarg (with `SE3` support)
was only ever implemented on `Shape.__init__`, one level below it.

- `SceneGroup` subclasses `SceneNode` directly (not `Shape`), so
  `SceneGroup(pose=SE3(...))` raised
  `TypeError: SceneNode.__init__() got an unexpected keyword argument 'pose'`
  -- only the raw `T=ndarray` kwarg worked.
- `CollisionShapeGroup` happened to accept `pose=` already, but only as a
  side effect of going through `CollisionShape`/`Shape` for unrelated
  reasons (it needs to be a `CollisionShape` for `isinstance` checks
  elsewhere), not because `pose` was deliberately designed to work there.

This moves `pose` (and its `SE3` -> `ndarray` conversion) down to
`SceneNode.__init__` itself, so every scene-graph node -- including groups
-- gets it consistently and for the right reason. `Shape.__init__`'s own
`base`/`pose` deprecation logic is unchanged; it now just forwards its
resolved value up as `pose=` instead of `T=`.

- [x] `SceneNode.__init__`: `T` renamed to `pose: ndarray | SE3`, same
  conversion `Shape.__init__` already did, plus a docstring (previously had
  none)
- [x] `SceneNode.__deepcopy__` and `Shape.__init__`'s `super().__init__()`
  call updated to the new kwarg name
- [x] Regression test: `SceneGroup(pose=...)` with both `SE3` and `ndarray`

## Test plan

- [x] `pytest tests/test_Shape.py tests/test_collision.py` -- 157 passed
- [x] Full suite: `pytest tests/` -- 160 passed
- [x] Confirmed `SceneGroup(pose=SE3(1,2,3))` no longer raises
- [x] Confirmed `base`/`pose` mutual-exclusivity `ValueError` on `Shape` still fires unchanged