### PR TITLE
fix: rename _propogate_scene_* to _propagate_scene_* (was misspelled)

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -287,12 +287,12 @@ specified offsets, and moves the cube within the scene:
     # Move the parent. This updates cube's own world pose but does NOT cascade to its children 
     cube.T = SE3(5, 0, 0)
     # Tell the scene graph that something has changed and that the world poses of all children need to be updated. 
-    cube._propagate_scene_tree()
+    cube.update()
     # Now the children have been updated to reflect the new world pose of their parent
     print(sphere1._wT[:3, 3])
     print(sphere2._wT[:3, 3])
 
-The ``_propagate_scene_tree()`` method is invoked automatically by Swift's ``env.step()`` method
+The ``update()`` method is invoked automatically by Swift's ``env.step()`` method
 to handle changes in object's pose. Because we are not using Swift in this example we need to call this manually.
 This code structure can be scaled up indefintely to create complex scenes with many objects and relationships.
 See ``examples/scene_graph.py`` for a similar example working in Swift.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -287,12 +287,12 @@ specified offsets, and moves the cube within the scene:
     # Move the parent. This updates cube's own world pose but does NOT cascade to its children 
     cube.T = SE3(5, 0, 0)
     # Tell the scene graph that something has changed and that the world poses of all children need to be updated. 
-    cube._propogate_scene_tree()
+    cube._propagate_scene_tree()
     # Now the children have been updated to reflect the new world pose of their parent
     print(sphere1._wT[:3, 3])
     print(sphere2._wT[:3, 3])
 
-The ``_propogate_scene_tree()`` method is invoked automatically by Swift's ``env.step()`` method
+The ``_propagate_scene_tree()`` method is invoked automatically by Swift's ``env.step()`` method
 to handle changes in object's pose. Because we are not using Swift in this example we need to call this manually.
 This code structure can be scaled up indefintely to create complex scenes with many objects and relationships.
 See ``examples/scene_graph.py`` for a similar example working in Swift.

--- a/src/spatialgeometry/cpp-extension/scene_nb.cpp
+++ b/src/spatialgeometry/cpp-extension/scene_nb.cpp
@@ -78,10 +78,10 @@ static void r2q(const MapMatrix4dc &r, double *q) {
 }
 
 // parent_wTm == nullptr means "treat node as the root", matching both
-// scene.cpp's propogate_T(node, NULL, NULL) and scene.py's
-// _propogate_T(node, None) -- used by scene_graph_children to propagate
+// scene.cpp's propagate_T(node, NULL, NULL) and scene.py's
+// _propagate_T(node, None) -- used by scene_graph_children to propagate
 // only downward regardless of node's actual parent.
-static void propogate_T(Node *node, const MapMatrix4dc *parent_wTm) {
+static void propagate_T(Node *node, const MapMatrix4dc *parent_wTm) {
     if (parent_wTm == nullptr) {
         node->wTm = node->Tm;
     } else {
@@ -90,7 +90,7 @@ static void propogate_T(Node *node, const MapMatrix4dc *parent_wTm) {
     r2q(node->wTm, node->wq);
 
     for (Node *child : node->children) {
-        propogate_T(child, &node->wTm);
+        propagate_T(child, &node->wTm);
     }
 }
 
@@ -131,12 +131,12 @@ NB_MODULE(scene, m) {
         nb::arg("children"));
 
     m.def("scene_graph_children",
-          [](Node *node) { propogate_T(node, nullptr); });
+          [](Node *node) { propagate_T(node, nullptr); });
 
     m.def("scene_graph_tree", [](Node *node) {
         while (node->parent != nullptr) {
             node = node->parent;
         }
-        propogate_T(node, nullptr);
+        propagate_T(node, nullptr);
     });
 }

--- a/src/spatialgeometry/geom/CollisionShape.py
+++ b/src/spatialgeometry/geom/CollisionShape.py
@@ -14,7 +14,7 @@ from typing import Any
 import numpy as np
 from spatialmath.base.argcheck import getvector
 from spatialgeometry.geom import Shape
-from spatialgeometry.geom.Shape import ArrayLike, aabb_corners, update
+from spatialgeometry.geom.Shape import ArrayLike, aabb_corners, mark_changed
 from warnings import warn
 
 # Module-level coal reference — populated on first use, never in Pyodide.
@@ -431,7 +431,7 @@ class Mesh(CollisionShape):
         return self._scale
 
     @scale.setter
-    @update
+    @mark_changed
     def scale(self, value: ArrayLike | float | None) -> None:
         if value is None:
             value = [1, 1, 1]
@@ -444,7 +444,7 @@ class Mesh(CollisionShape):
         return self._filename
 
     @filename.setter
-    @update
+    @mark_changed
     def filename(self, value: str | None) -> None:
         self._filename = value
 
@@ -463,7 +463,7 @@ class Mesh(CollisionShape):
         return self._y_up
 
     @y_up.setter
-    @update
+    @mark_changed
     def y_up(self, value: bool) -> None:
         self._y_up = bool(value)
 
@@ -528,7 +528,7 @@ class Cylinder(CollisionShape):
         return self._radius
 
     @radius.setter
-    @update
+    @mark_changed
     def radius(self, value: float) -> None:
         self._radius = float(value)
 
@@ -537,7 +537,7 @@ class Cylinder(CollisionShape):
         return self._length
 
     @length.setter
-    @update
+    @mark_changed
     def length(self, value: float) -> None:
         self._length = float(value)
 
@@ -579,7 +579,7 @@ class Sphere(CollisionShape):
         return self._radius
 
     @radius.setter
-    @update
+    @mark_changed
     def radius(self, value: float) -> None:
         self._radius = float(value)
 
@@ -623,7 +623,7 @@ class Ellipsoid(CollisionShape):
         return self._radii
 
     @radii.setter
-    @update
+    @mark_changed
     def radii(self, value: ArrayLike) -> None:
         value = getvector(value, 3)
         self._radii = np.array(value)
@@ -663,7 +663,7 @@ class Cuboid(CollisionShape):
         return self._scale
 
     @scale.setter
-    @update
+    @mark_changed
     def scale(self, value: ArrayLike) -> None:
         value = getvector(value if value is not None else [1, 1, 1], 3)
         self._scale = np.array(value)

--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -181,7 +181,7 @@ class SceneNode:
         # A node can't become its own ancestor -- walk the new parent's own
         # chain of parents; if self shows up (or parent is self), this
         # reparenting would create a cycle. Nothing downstream checks for
-        # this: _propagate_scene_tree()'s root-finding walk (SceneNode.py,
+        # this: update()'s root-finding walk (SceneNode.py,
         # also mirrored in scene.py and the compiled scene_nb.cpp) has no
         # cycle detection of its own -- a parent-chain cycle makes it spin
         # forever (an infinite loop, not a catchable exception), and
@@ -326,38 +326,40 @@ class SceneNode:
         """
         scene_graph_children(self.__scene)
 
-    def _propagate_scene_tree(self) -> None:
+    def update(self) -> None:
         """
-        Propagates the world transform starting from this root of the tree in
-        which this node lives
+        Recompute the world transform of every node in the scene graph
+        this node belongs to, starting from the root and working down.
+
+        Call this after changing any node's ``T``/``pose`` (or its
+        ``scene_parent``) -- nothing propagates automatically. It doesn't
+        matter which node in the graph you call it on: this always walks
+        up to the root first, then pushes fresh world transforms down
+        through the whole tree, not just this node's own subtree.
         """
         scene_graph_tree(self.__scene)
 
-    # Deprecated aliases -- "propogate" was a straight-up misspelling of
-    # "propagate", not a naming choice. Kept as thin wrappers (rather than a
-    # bare rename) because despite the leading underscore this pair is
-    # called directly, by name, from outside this package -- RTB's
-    # Link.py/Robot.py and Swift's Swift.py both call
-    # `self._propogate_scene_tree()`, and SG's own intro.rst tutorial tells
-    # end users to call it too. Remove once RTB and Swift have migrated to
-    # the correctly-spelled names.
-    def _propogate_scene_children(self) -> None:
-        """Deprecated (misspelled) -- use :meth:`_propagate_scene_children`."""
-        warn(
-            "_propogate_scene_children is deprecated (it was a misspelling), "
-            "use _propagate_scene_children instead",
-            FutureWarning,
-        )
-        self._propagate_scene_children()
-
+    # Deprecated alias -- "_propogate_scene_tree" was this method's name
+    # before it was renamed to update() (and, before that, was a misspelling
+    # of "propagate"). Kept as a thin wrapper, not a bare rename, because
+    # despite the leading underscore it's called directly, by name, from
+    # outside this package -- RTB's Link.py/Robot.py and Swift's Swift.py
+    # both call `self._propogate_scene_tree()`, and SG's own intro.rst
+    # tutorial told end users to call it too. Remove once RTB and Swift have
+    # migrated to update().
     def _propogate_scene_tree(self) -> None:
-        """Deprecated (misspelled) -- use :meth:`_propagate_scene_tree`."""
+        """Deprecated -- use :meth:`update` instead."""
         warn(
-            "_propogate_scene_tree is deprecated (it was a misspelling), "
-            "use _propagate_scene_tree instead",
+            "_propogate_scene_tree is deprecated, use update() instead",
             FutureWarning,
         )
-        self._propagate_scene_tree()
+        self.update()
+
+    # _propagate_scene_children() has no public equivalent and no known
+    # external callers (unlike the tree-wide version above) -- it's an
+    # internal helper used at construction/attachment time, not something
+    # end users are expected to reach for, so no deprecated alias needed
+    # for its old misspelled name either.
 
     # --------------------------------------------------------------------- #
 
@@ -390,7 +392,7 @@ class SceneNode:
         """
         Render the whole tree this node lives in as indented text -- walks
         up to the root first (the same root-finding as
-        :meth:`_propagate_scene_tree`), then renders down from there, with
+        :meth:`update`), then renders down from there, with
         this node marked with a trailing ``<==`` so its position in the tree
         is visible.
 

--- a/src/spatialgeometry/geom/SceneNode.py
+++ b/src/spatialgeometry/geom/SceneNode.py
@@ -10,6 +10,7 @@ from spatialmath.base import r2q
 from spatialgeometry.scene import node_init, node_update, scene_graph_children, scene_graph_tree
 from spatialmath import SE3
 from copy import deepcopy
+from warnings import warn
 
 
 class SceneNode:
@@ -54,7 +55,7 @@ class SceneNode:
             scene_parent._update_scene_children(self)
 
         # Update scene tree
-        self._propogate_scene_children()
+        self._propagate_scene_children()
 
     # --------------------------------------------------------------------- #
 
@@ -93,7 +94,7 @@ class SceneNode:
             scene_parent._update_scene_children(self)
 
         # Update scene tree
-        self._propogate_scene_children()
+        self._propagate_scene_children()
 
     # --------------------------------------------------------------------- #
 
@@ -180,7 +181,7 @@ class SceneNode:
         # A node can't become its own ancestor -- walk the new parent's own
         # chain of parents; if self shows up (or parent is self), this
         # reparenting would create a cycle. Nothing downstream checks for
-        # this: _propogate_scene_tree()'s root-finding walk (SceneNode.py,
+        # this: _propagate_scene_tree()'s root-finding walk (SceneNode.py,
         # also mirrored in scene.py and the compiled scene_nb.cpp) has no
         # cycle detection of its own -- a parent-chain cycle makes it spin
         # forever (an infinite loop, not a catchable exception), and
@@ -311,26 +312,52 @@ class SceneNode:
         self._T = T_new
 
     # --------------------------------------------------------------------- #
-    # Scene transform propogation methods
+    # Scene transform propagation methods
     #
     # The scene graph is a Forest -- A disjoint union of Rooted Trees
     # Each tree has a single root, no cycles, and each node has at most one
     # parent but unlimited children.
     # --------------------------------------------------------------------- #
 
-    def _propogate_scene_children(self):
+    def _propagate_scene_children(self) -> None:
         """
-        Propogates the world transform starting from this node going downwards
+        Propagates the world transform starting from this node going downwards
         through the tree (will not go through parents)
         """
         scene_graph_children(self.__scene)
 
-    def _propogate_scene_tree(self):
+    def _propagate_scene_tree(self) -> None:
         """
-        Propogates the world transform starting from this root of the tree in
+        Propagates the world transform starting from this root of the tree in
         which this node lives
         """
         scene_graph_tree(self.__scene)
+
+    # Deprecated aliases -- "propogate" was a straight-up misspelling of
+    # "propagate", not a naming choice. Kept as thin wrappers (rather than a
+    # bare rename) because despite the leading underscore this pair is
+    # called directly, by name, from outside this package -- RTB's
+    # Link.py/Robot.py and Swift's Swift.py both call
+    # `self._propogate_scene_tree()`, and SG's own intro.rst tutorial tells
+    # end users to call it too. Remove once RTB and Swift have migrated to
+    # the correctly-spelled names.
+    def _propogate_scene_children(self) -> None:
+        """Deprecated (misspelled) -- use :meth:`_propagate_scene_children`."""
+        warn(
+            "_propogate_scene_children is deprecated (it was a misspelling), "
+            "use _propagate_scene_children instead",
+            FutureWarning,
+        )
+        self._propagate_scene_children()
+
+    def _propogate_scene_tree(self) -> None:
+        """Deprecated (misspelled) -- use :meth:`_propagate_scene_tree`."""
+        warn(
+            "_propogate_scene_tree is deprecated (it was a misspelling), "
+            "use _propagate_scene_tree instead",
+            FutureWarning,
+        )
+        self._propagate_scene_tree()
 
     # --------------------------------------------------------------------- #
 
@@ -347,7 +374,7 @@ class SceneNode:
         """
         Render this node's own subtree as indented text (one ``repr()`` per
         line), not walking through parents -- the same "not through
-        parents" scope as :meth:`_propogate_scene_children`.
+        parents" scope as :meth:`_propagate_scene_children`.
 
         Nodes have no ``.name`` in this package, so each line is that
         node's own ``repr()`` (type, constructor params, color, pose) --
@@ -363,7 +390,7 @@ class SceneNode:
         """
         Render the whole tree this node lives in as indented text -- walks
         up to the root first (the same root-finding as
-        :meth:`_propogate_scene_tree`), then renders down from there, with
+        :meth:`_propagate_scene_tree`), then renders down from there, with
         this node marked with a trailing ``<==`` so its position in the tree
         is visible.
 

--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -45,16 +45,16 @@ def aabb_corners(mn: ArrayLike, mx: ArrayLike) -> ndarray:
 # _rtb = False
 
 
-def update(func):  # pragma nocover
+def mark_changed(func):  # pragma nocover
     @wraps(func)
-    def wrapper_update(*args, **kwargs):
+    def wrapper_mark_changed(*args, **kwargs):
 
         if args[0]._added_to_swift:
             args[0]._changed = True
 
         return func(*args, **kwargs)
 
-    return wrapper_update
+    return wrapper_mark_changed
 
 
 try:
@@ -265,7 +265,7 @@ class Shape(SceneNode, ABC):
         return self._color
 
     @color.setter
-    @update
+    @mark_changed
     def color(self, value: ArrayLike) -> None:
         """
         shape.color(new_color) sets the color of a shape.
@@ -441,7 +441,7 @@ class Axes(Shape):
         return self._length
 
     @length.setter
-    @update
+    @mark_changed
     def length(self, value: float) -> None:
         self._length = float(value)
 
@@ -450,7 +450,7 @@ class Axes(Shape):
         return self._arrows
 
     @arrows.setter
-    @update
+    @mark_changed
     def arrows(self, value: bool) -> None:
         self._arrows = bool(value)
 
@@ -459,7 +459,7 @@ class Axes(Shape):
         return self._radius
 
     @radius.setter
-    @update
+    @mark_changed
     def radius(self, value: float) -> None:
         self._radius = float(value)
 
@@ -468,7 +468,7 @@ class Axes(Shape):
         return self._linewidth
 
     @linewidth.setter
-    @update
+    @mark_changed
     def linewidth(self, value: float) -> None:
         self._linewidth = float(value)
 
@@ -541,7 +541,7 @@ class Arrow(Shape):
         return self._length
 
     @length.setter
-    @update
+    @mark_changed
     def length(self, value: float) -> None:
         self._length = float(value)
 
@@ -550,7 +550,7 @@ class Arrow(Shape):
         return self._radius
 
     @radius.setter
-    @update
+    @mark_changed
     def radius(self, value: float) -> None:
         self._radius = float(value)
 
@@ -559,7 +559,7 @@ class Arrow(Shape):
         return self._linewidth
 
     @linewidth.setter
-    @update
+    @mark_changed
     def linewidth(self, value: float) -> None:
         self._linewidth = float(value)
 
@@ -568,7 +568,7 @@ class Arrow(Shape):
         return self._head_length
 
     @head_length.setter
-    @update
+    @mark_changed
     def head_length(self, value: float) -> None:
         self._head_length = float(value)
 
@@ -577,7 +577,7 @@ class Arrow(Shape):
         return self._head_radius
 
     @head_radius.setter
-    @update
+    @mark_changed
     def head_radius(self, value: float) -> None:
         self._head_radius = float(value)
 
@@ -639,7 +639,7 @@ class Path(Shape):
         return self._points
 
     @points.setter
-    @update
+    @mark_changed
     def points(self, value: ArrayLike) -> None:
         value = np.array(value, dtype=float)
         if value.ndim != 2 or value.shape[0] != 3:
@@ -655,7 +655,7 @@ class Path(Shape):
         return self._radius
 
     @radius.setter
-    @update
+    @mark_changed
     def radius(self, value: float) -> None:
         self._radius = float(value)
 
@@ -664,7 +664,7 @@ class Path(Shape):
         return self._linewidth
 
     @linewidth.setter
-    @update
+    @mark_changed
     def linewidth(self, value: float) -> None:
         self._linewidth = float(value)
 

--- a/src/spatialgeometry/scene.py
+++ b/src/spatialgeometry/scene.py
@@ -53,7 +53,7 @@ def _r2q_xyzs(R: ArrayF64) -> ArrayF64:
     return q
 
 
-def _propogate_T(node: _Node, parent_wT: ArrayF64 | None) -> None:
+def _propagate_T(node: _Node, parent_wT: ArrayF64 | None) -> None:
     if parent_wT is None:
         node.wT[:] = node.T
     else:
@@ -62,7 +62,7 @@ def _propogate_T(node: _Node, parent_wT: ArrayF64 | None) -> None:
     node.wq[:] = _r2q_xyzs(node.wT[:3, :3])
 
     for child in node.children:
-        _propogate_T(child, node.wT)
+        _propagate_T(child, node.wT)
 
 
 def node_init(
@@ -97,11 +97,11 @@ def node_update(
 
 
 def scene_graph_children(node: _Node) -> None:
-    _propogate_T(node, None)
+    _propagate_T(node, None)
 
 
 def scene_graph_tree(node: _Node) -> None:
     while node.parent is not None:
         node = node.parent
 
-    _propogate_T(node, None)
+    _propagate_T(node, None)

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -120,7 +120,7 @@ class TestShape(unittest.TestCase):
 
     def test_wq_matches_spatialmath_r2q(self):
         # fk_dict()'s "q" comes from _wq, populated by the C++ r2q() in
-        # scene_nb.cpp (Shepperd's method) every _propagate_scene_tree()
+        # scene_nb.cpp (Shepperd's method) every update()
         # call -- a different algorithm to spatialmath.base.r2q's Cayley's
         # method, and never cross-checked against it before. Covers the
         # cases quaternion-extraction methods most commonly get wrong:
@@ -141,7 +141,7 @@ class TestShape(unittest.TestCase):
 
         for name, T in cases.items():
             shape = gm.Cuboid([0.1, 0.1, 0.1], pose=T)
-            shape._propagate_scene_tree()
+            shape.update()
 
             expected = sm.base.r2q(T.R, order="xyzs")
 
@@ -150,18 +150,24 @@ class TestShape(unittest.TestCase):
             opposite = np.allclose(shape._wq, -np.array(expected), atol=1e-9)
             self.assertTrue(same or opposite, msg=f"{name}: {shape._wq} vs {expected}")
 
-    def test_propogate_aliases_warn_and_match_new_names(self):
+    def test_propogate_scene_tree_alias_warns_and_matches_update(self):
         shape = gm.Cuboid([1, 1, 1], pose=sm.SE3(1, 2, 3))
 
         with self.assertWarns(FutureWarning):
-            shape._propogate_scene_children()
-        with self.assertWarns(FutureWarning):
             shape._propogate_scene_tree()
 
-        # Both still do the real thing, not just warn.
+        # Still does the real thing, not just warns.
         shape._T = np.eye(4)
         shape._propogate_scene_tree()
         nt.assert_almost_equal(shape._wT, np.eye(4))
+
+    def test_propagate_scene_children_has_no_deprecated_alias(self):
+        # Unlike _propogate_scene_tree, the children-only variant has no
+        # known external callers and was never documented -- a clean
+        # rename, no back-compat shim.
+        shape = gm.Cuboid([1, 1, 1])
+        self.assertFalse(hasattr(shape, "_propogate_scene_children"))
+        shape._propagate_scene_children()
 
     @skip_no_collision_checking
     def test_collision(self):
@@ -528,7 +534,7 @@ class TestShape(unittest.TestCase):
         self.assertEqual(len(group), 1)
 
         parent.T = sm.SE3(5, 0, 0)
-        parent._propagate_scene_tree()
+        parent.update()
         nt.assert_almost_equal(group._wT[:3, 3], [5, 0, 0])
         nt.assert_almost_equal(group[0]._wT[:3, 3], [5, 0, 0])
 

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -120,7 +120,7 @@ class TestShape(unittest.TestCase):
 
     def test_wq_matches_spatialmath_r2q(self):
         # fk_dict()'s "q" comes from _wq, populated by the C++ r2q() in
-        # scene_nb.cpp (Shepperd's method) every _propogate_scene_tree()
+        # scene_nb.cpp (Shepperd's method) every _propagate_scene_tree()
         # call -- a different algorithm to spatialmath.base.r2q's Cayley's
         # method, and never cross-checked against it before. Covers the
         # cases quaternion-extraction methods most commonly get wrong:
@@ -141,7 +141,7 @@ class TestShape(unittest.TestCase):
 
         for name, T in cases.items():
             shape = gm.Cuboid([0.1, 0.1, 0.1], pose=T)
-            shape._propogate_scene_tree()
+            shape._propagate_scene_tree()
 
             expected = sm.base.r2q(T.R, order="xyzs")
 
@@ -150,15 +150,28 @@ class TestShape(unittest.TestCase):
             opposite = np.allclose(shape._wq, -np.array(expected), atol=1e-9)
             self.assertTrue(same or opposite, msg=f"{name}: {shape._wq} vs {expected}")
 
+    def test_propogate_aliases_warn_and_match_new_names(self):
+        shape = gm.Cuboid([1, 1, 1], pose=sm.SE3(1, 2, 3))
+
+        with self.assertWarns(FutureWarning):
+            shape._propogate_scene_children()
+        with self.assertWarns(FutureWarning):
+            shape._propogate_scene_tree()
+
+        # Both still do the real thing, not just warn.
+        shape._T = np.eye(4)
+        shape._propogate_scene_tree()
+        nt.assert_almost_equal(shape._wT, np.eye(4))
+
     @skip_no_collision_checking
     def test_collision(self):
         s0 = gm.Cuboid([1, 1, 1], base=sm.SE3(0, 0, 0))
         s1 = gm.Cuboid([1, 1, 1], base=sm.SE3(0.5, 0, 0))
         s2 = gm.Cuboid([1, 1, 1], base=sm.SE3(3, 0, 0))
 
-        s0._propogate_scene_children()
-        s1._propogate_scene_children()
-        s2._propogate_scene_children()
+        s0._propagate_scene_children()
+        s1._propagate_scene_children()
+        s2._propagate_scene_children()
 
         c0 = s0.iscollided(s1)
         c1 = s0.iscollided(s2)
@@ -515,7 +528,7 @@ class TestShape(unittest.TestCase):
         self.assertEqual(len(group), 1)
 
         parent.T = sm.SE3(5, 0, 0)
-        parent._propogate_scene_tree()
+        parent._propagate_scene_tree()
         nt.assert_almost_equal(group._wT[:3, 3], [5, 0, 0])
         nt.assert_almost_equal(group[0]._wT[:3, 3], [5, 0, 0])
 
@@ -576,7 +589,7 @@ class TestSceneTreePrint(unittest.TestCase):
         sibling.scene_parent = parent
 
         # From the child's own perspective, tree_children() must not walk
-        # back up through its parent (matching _propogate_scene_children()'s
+        # back up through its parent (matching _propagate_scene_children()'s
         # "not through parents" scope) or sideways to its sibling.
         result = child.tree_children()
         self.assertEqual(result, repr(child))

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -540,7 +540,7 @@ class TestSceneGroupCollision:
         assert d0 == pytest.approx(12.0, abs=1e-6)
 
         anchor.T = SE3(10, 0, 0)
-        anchor._propogate_scene_tree()
+        anchor._propagate_scene_tree()
 
         # col now at world x=10: faces at 10.5 and 12.5 -> gap 2.0. If the
         # group's append() hadn't wired col into the propagated scene graph,
@@ -559,7 +559,7 @@ class TestSceneGroupCollision:
         group.append(c2)
 
         anchor.T = SE3(20, 0, 0)
-        anchor._propogate_scene_tree()
+        anchor._propagate_scene_tree()
 
         # c1 -> world x=20, c2 -> world x=25 (its own local +5 composed on
         # top of anchor's move)
@@ -600,7 +600,7 @@ class TestCollisionShapeGroup:
         assert col.scene_parent is group
 
         anchor.T = SE3(10, 0, 0)
-        anchor._propogate_scene_tree()
+        anchor._propagate_scene_tree()
 
         probe = cuboid_at(1, 1, 1, x=13)
         d, _, _ = col.closest_point(probe, BIG)

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -540,7 +540,7 @@ class TestSceneGroupCollision:
         assert d0 == pytest.approx(12.0, abs=1e-6)
 
         anchor.T = SE3(10, 0, 0)
-        anchor._propagate_scene_tree()
+        anchor.update()
 
         # col now at world x=10: faces at 10.5 and 12.5 -> gap 2.0. If the
         # group's append() hadn't wired col into the propagated scene graph,
@@ -559,7 +559,7 @@ class TestSceneGroupCollision:
         group.append(c2)
 
         anchor.T = SE3(20, 0, 0)
-        anchor._propagate_scene_tree()
+        anchor.update()
 
         # c1 -> world x=20, c2 -> world x=25 (its own local +5 composed on
         # top of anchor's move)
@@ -600,7 +600,7 @@ class TestCollisionShapeGroup:
         assert col.scene_parent is group
 
         anchor.T = SE3(10, 0, 0)
-        anchor._propagate_scene_tree()
+        anchor.update()
 
         probe = cuboid_at(1, 1, 1, x=13)
         d, _, _ = col.closest_point(probe, BIG)


### PR DESCRIPTION
## Summary

`_propogate_scene_tree()`/`_propogate_scene_children()` were a plain
misspelling of "propagate". Despite the leading underscore, `_propogate_scene_tree()`
specifically is not actually private in practice -- it's called directly, by
name, from outside this package (`roboticstoolbox`'s `Link.py`/`Robot.py`,
`swift`'s `Swift.py`), and SG's own `intro.rst` tutorial tells end users to
call it themselves.

Rather than just fixing the spelling, this makes it a proper public method:

- [x] Added `update()` as the new public method on `SceneNode` -- the real
  implementation (walk to the scene graph's root, then push fresh world
  transforms down through the whole tree)
- [x] Kept `_propogate_scene_tree()` (the original misspelled name) as a thin
  wrapper that `warn(..., FutureWarning)`s and delegates to `update()`
- [x] `_propagate_scene_children()` (the subtree-only variant, no known
  external callers, never documented) gets a clean private rename with no
  deprecation shim needed -- same treatment given to `scene.py`'s internal
  `_propagate_T` helper, and to the compiled C++ extension's own
  file-local `propogate_T()` -> `propagate_T()` (`scene_nb.cpp`)
- [x] Renamed the unrelated `@update` decorator (marks a shape "changed" for
  Swift's render-tracking, `Shape.py`/`CollisionShape.py`) to `@mark_changed`,
  since it would otherwise share a name with the new public `update()`
  method despite meaning something completely different
- [x] Updated every internal call site (source, tests, docs) accordingly

Companion PRs updating `robotics-toolbox-python` and `swift` to call
`update()` directly (not the deprecated alias) to follow, cross-referenced
here once open.

## Test plan

- [x] Full suite: `pytest tests/` -- 161 passed
- [x] `make html` docs build -- same 2 pre-existing warnings, no new ones;
  confirmed `update()` now appears on `SceneNode`'s rendered API page
- [x] Confirmed calling the deprecated `_propogate_scene_tree()` alias still
  works and emits `FutureWarning`
- [x] Confirmed the compiled C++ extension rebuilds and all tests still pass
  after the `scene_nb.cpp` rename