### PR TITLE
fix: opacity property's @update decorator was never renamed to @mark_changed

### DIFF
--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -374,7 +374,7 @@ class Shape(SceneNode, ABC):
         return self._color[3]
 
     @opacity.setter
-    @update
+    @mark_changed
     def opacity(self, value: float) -> None:
         if value > 1.0:
             value /= 255


### PR DESCRIPTION
## Summary

**`main` is currently broken** -- `import spatialgeometry` raises
`NameError: name 'update' is not defined`.

#34 (opacity property) and #38 (renamed the `@update` decorator to
`@mark_changed`, since it collided with the new public `SceneNode.update()`
method) were both branched independently before either merged, so neither
PR's diff touched the other's code. #38 merged first; then #34's own new
`opacity` setter -- still using the pre-rename `@update` -- merged cleanly
on top with no conflict, silently reintroducing a decorator name that no
longer exists.

## Test plan

- [x] `import spatialgeometry` -- confirmed `NameError` before this fix,
  confirmed clean after
- [x] Full suite: `pytest tests/` -- 167 passed