### PR TITLE
feat: add Arrow.FromTo(start, end) classmethod

### DIFF
--- a/src/spatialgeometry/geom/Shape.py
+++ b/src/spatialgeometry/geom/Shape.py
@@ -623,6 +623,48 @@ class Arrow(Shape):
         self.head_length = head_length
         self.head_radius = head_radius
 
+    @classmethod
+    def FromTo(cls, start: ArrayLike, end: ArrayLike, **kwargs) -> Arrow:
+        """
+        Construct an Arrow spanning from ``start`` to ``end``.
+
+        :param start: 3-vector, world-frame point the arrow points from
+        :param end: 3-vector, world-frame point the arrow points to
+        :param kwargs: passed through to the constructor (``radius``,
+            ``linewidth``, ``head_length``, ``head_radius``, ``color``, ...)
+
+        ``length`` and ``pose`` are computed from ``start``/``end`` --
+        don't pass them directly.
+
+        :raises ValueError: if ``start`` and ``end`` are the same point
+            (the direction, and therefore the pose, would be undefined)
+
+        :rtype: Arrow
+        """
+        start = np.asarray(start, dtype=float)
+        end = np.asarray(end, dtype=float)
+        delta = end - start
+        length = float(np.linalg.norm(delta))
+        if length == 0:
+            raise ValueError("start and end must be different points")
+        direction = delta / length
+
+        # SE3.OA(o, a) constructs a frame with a as its Z-axis directly,
+        # rather than computing a delta rotation from a fixed reference --
+        # that sidesteps the antipodal singularity a naive "rotate +Z to
+        # direction" approach hits (e.g. spatialmath's own
+        # SE3.RotatedVector currently returns identity, not a 180 degree
+        # flip, when direction is exactly -Z; see
+        # bdaiinstitute/spatialmath-python fix/rotatedvector-antipodal).
+        # o only needs to be non-parallel to direction -- the arrow shaft
+        # is rotationally symmetric, so which valid o we pick is
+        # irrelevant. World Z is fine unless direction is itself close to
+        # parallel to it, in which case fall back to world X.
+        reference = [0, 0, 1] if abs(direction[2]) < 0.9 else [1, 0, 0]
+        pose = SE3.Rt(SE3.OA(reference, direction).R, (start + end) / 2)
+
+        return cls(length, pose=pose, **kwargs)
+
     @property
     def length(self) -> float:
         """

--- a/tests/test_Shape.py
+++ b/tests/test_Shape.py
@@ -484,6 +484,37 @@ class TestShape(unittest.TestCase):
         self.assertEqual(d["radius"], 0.1)
         self.assertEqual(d["linewidth"], 5.0)
 
+    def test_Arrow_FromTo_length_and_pose(self):
+        cases = {
+            "general": ([0, 0, 0], [1, 1, 1]),
+            "along_+z": ([0, 0, 0], [0, 0, 5]),
+            "along_-z": ([0, 0, 0], [0, 0, -5]),  # antipodal to local +Z
+            "along_+x": ([1, 2, 3], [6, 2, 3]),
+            "along_-y": ([0, 0, 0], [0, -2, 0]),
+        }
+        for name, (start, end) in cases.items():
+            start = np.array(start, dtype=float)
+            end = np.array(end, dtype=float)
+            a = gm.Arrow.FromTo(start, end)
+
+            expected_length = np.linalg.norm(end - start)
+            self.assertAlmostEqual(a.length, expected_length, msg=name)
+
+            nt.assert_almost_equal(a.T[:3, 3], (start + end) / 2, err_msg=name)
+
+            expected_direction = (end - start) / expected_length
+            actual_direction = a.T[:3, :3] @ np.array([0.0, 0.0, 1.0])
+            nt.assert_almost_equal(actual_direction, expected_direction, err_msg=name)
+
+    def test_Arrow_FromTo_rejects_coincident_points(self):
+        with self.assertRaises(ValueError):
+            gm.Arrow.FromTo([1, 2, 3], [1, 2, 3])
+
+    def test_Arrow_FromTo_passes_through_kwargs(self):
+        a = gm.Arrow.FromTo([0, 0, 0], [1, 0, 0], color="red", radius=0.05)
+        self.assertEqual(a.color, (1.0, 0.0, 0.0, 1.0))
+        self.assertEqual(a.radius, 0.05)
+
     def test_repr_distinguishes_deprecated_alias_from_its_base(self):
         # Box is a deprecated alias of Cuboid sharing the same stype --
         # repr must still tell them apart (it used to show "cuboid" for


### PR DESCRIPTION
## Summary

- New `Arrow.FromTo(start, end, **kwargs)` classmethod -- constructs an
  `Arrow` spanning two 3-vectors, computing `length` and `pose`
  automatically instead of requiring the caller to do it by hand.
- `**kwargs` pass straight through to the constructor (`color`, `radius`,
  `linewidth`, `head_length`, `head_radius`, ...).
- Uses `SE3.OA(reference, direction)` to build the pose, not a delta
  rotation from a fixed reference -- that class of approach (e.g.
  spatialmath's own `SE3.RotatedVector`) has an antipodal singularity:
  confirmed live that `SE3.RotatedVector([0,0,1], [0,0,-1])` currently
  returns identity instead of the correct 180° flip, since the cross
  product used to find the rotation axis is zero right at that point.
  `SE3.OA` sidesteps this entirely by directly specifying the target
  frame's axes rather than computing a delta from Z. Companion fix
  proposed upstream for the underlying bug:
  [bdaiinstitute/spatialmath-python, branch `fix/rotatedvector-antipodal`](https://github.com/bdaiinstitute/spatialmath-python)
  (PR to follow).
- `reference` (the `OA` "orientation" vector) only needs to be
  non-parallel to `direction` -- which valid one gets picked is
  irrelevant, since the arrow shaft is rotationally symmetric.
- Raises `ValueError` if `start == end` (direction, and therefore pose,
  would be undefined).

## Test plan

- [x] `pytest tests/` -- 172 passed
- [x] Covers: length/pose correctness across general, axis-aligned, and
  antipodal-to-world-Z directions (proving the antipodal case this PR is
  specifically designed to avoid actually works); coincident-points
  `ValueError`; kwargs pass-through