### PR TITLE
docs: correct CHANGELOG's 1.4.0 date to the actual release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to this project are documented in this file. Starts from
 v1.2.0 — earlier releases aren't documented retroactively.
 
-## [1.4.0] - 2026-08-09
+## [1.4.0] - 2026-08-23
 
 ### New
 


### PR DESCRIPTION
The 2026-08-09 date was when this entry was drafted, before merge -- correcting it to the date 1.4.0 is actually being released.