### PR TITLE
ci: rename workflow to CI for badge consistency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 # Run tests and build/deploy docs.
 # Triggers on pushes to main and on PRs targeting main.
 
-name: Run Tests and Build Docs
+name: CI
 
 on:
   push:


### PR DESCRIPTION
The workflow was named \`Run Tests and Build Docs\`, which is what its GitHub Actions badge displays. Renaming it to \`CI\` aligns the badge label with the other repos in the RVC ecosystem, all of which already show a consistent "CI" badge rather than a repo-specific workflow name.

No functional change to the workflow itself.